### PR TITLE
Add null safety

### DIFF
--- a/lib/ionicons.dart
+++ b/lib/ionicons.dart
@@ -14,3999 +14,3999 @@ class IoniconsData extends IconData {
 /// Ionicons data, see https://ionicons.com/ for more info
 class Ionicons {
   /// accessibility
-  static const IconData? accessibility = IoniconsData(0xe900);
+  static const IconData accessibility = IoniconsData(0xe900);
 
   /// accessibility-outline
-  static const IconData? accessibility_outline = IoniconsData(0xe901);
+  static const IconData accessibility_outline = IoniconsData(0xe901);
 
   /// accessibility-sharp
-  static const IconData? accessibility_sharp = IoniconsData(0xe902);
+  static const IconData accessibility_sharp = IoniconsData(0xe902);
 
   /// add
-  static const IconData? add = IoniconsData(0xe903);
+  static const IconData add = IoniconsData(0xe903);
 
   /// add-circle
-  static const IconData? add_circle = IoniconsData(0xe904);
+  static const IconData add_circle = IoniconsData(0xe904);
 
   /// add-circle-outline
-  static const IconData? add_circle_outline = IoniconsData(0xe905);
+  static const IconData add_circle_outline = IoniconsData(0xe905);
 
   /// add-circle-sharp
-  static const IconData? add_circle_sharp = IoniconsData(0xe906);
+  static const IconData add_circle_sharp = IoniconsData(0xe906);
 
   /// add-outline
-  static const IconData? add_outline = IoniconsData(0xe907);
+  static const IconData add_outline = IoniconsData(0xe907);
 
   /// add-sharp
-  static const IconData? add_sharp = IoniconsData(0xe908);
+  static const IconData add_sharp = IoniconsData(0xe908);
 
   /// airplane
-  static const IconData? airplane = IoniconsData(0xe909);
+  static const IconData airplane = IoniconsData(0xe909);
 
   /// airplane-outline
-  static const IconData? airplane_outline = IoniconsData(0xe90a);
+  static const IconData airplane_outline = IoniconsData(0xe90a);
 
   /// airplane-sharp
-  static const IconData? airplane_sharp = IoniconsData(0xe90b);
+  static const IconData airplane_sharp = IoniconsData(0xe90b);
 
   /// alarm
-  static const IconData? alarm = IoniconsData(0xe90c);
+  static const IconData alarm = IoniconsData(0xe90c);
 
   /// alarm-outline
-  static const IconData? alarm_outline = IoniconsData(0xe90d);
+  static const IconData alarm_outline = IoniconsData(0xe90d);
 
   /// alarm-sharp
-  static const IconData? alarm_sharp = IoniconsData(0xe90e);
+  static const IconData alarm_sharp = IoniconsData(0xe90e);
 
   /// albums
-  static const IconData? albums = IoniconsData(0xe90f);
+  static const IconData albums = IoniconsData(0xe90f);
 
   /// albums-outline
-  static const IconData? albums_outline = IoniconsData(0xe910);
+  static const IconData albums_outline = IoniconsData(0xe910);
 
   /// albums-sharp
-  static const IconData? albums_sharp = IoniconsData(0xe911);
+  static const IconData albums_sharp = IoniconsData(0xe911);
 
   /// alert
-  static const IconData? alert = IoniconsData(0xe912);
+  static const IconData alert = IoniconsData(0xe912);
 
   /// alert-circle
-  static const IconData? alert_circle = IoniconsData(0xe913);
+  static const IconData alert_circle = IoniconsData(0xe913);
 
   /// alert-circle-outline
-  static const IconData? alert_circle_outline = IoniconsData(0xe914);
+  static const IconData alert_circle_outline = IoniconsData(0xe914);
 
   /// alert-circle-sharp
-  static const IconData? alert_circle_sharp = IoniconsData(0xe915);
+  static const IconData alert_circle_sharp = IoniconsData(0xe915);
 
   /// alert-outline
-  static const IconData? alert_outline = IoniconsData(0xe916);
+  static const IconData alert_outline = IoniconsData(0xe916);
 
   /// alert-sharp
-  static const IconData? alert_sharp = IoniconsData(0xe917);
+  static const IconData alert_sharp = IoniconsData(0xe917);
 
   /// american-football
-  static const IconData? american_football = IoniconsData(0xe918);
+  static const IconData american_football = IoniconsData(0xe918);
 
   /// american-football-outline
-  static const IconData? american_football_outline = IoniconsData(0xe919);
+  static const IconData american_football_outline = IoniconsData(0xe919);
 
   /// american-football-sharp
-  static const IconData? american_football_sharp = IoniconsData(0xe91a);
+  static const IconData american_football_sharp = IoniconsData(0xe91a);
 
   /// analytics
-  static const IconData? analytics = IoniconsData(0xe91b);
+  static const IconData analytics = IoniconsData(0xe91b);
 
   /// analytics-outline
-  static const IconData? analytics_outline = IoniconsData(0xe91c);
+  static const IconData analytics_outline = IoniconsData(0xe91c);
 
   /// analytics-sharp
-  static const IconData? analytics_sharp = IoniconsData(0xe91d);
+  static const IconData analytics_sharp = IoniconsData(0xe91d);
 
   /// aperture
-  static const IconData? aperture = IoniconsData(0xe91e);
+  static const IconData aperture = IoniconsData(0xe91e);
 
   /// aperture-outline
-  static const IconData? aperture_outline = IoniconsData(0xe91f);
+  static const IconData aperture_outline = IoniconsData(0xe91f);
 
   /// aperture-sharp
-  static const IconData? aperture_sharp = IoniconsData(0xe920);
+  static const IconData aperture_sharp = IoniconsData(0xe920);
 
   /// apps
-  static const IconData? apps = IoniconsData(0xe921);
+  static const IconData apps = IoniconsData(0xe921);
 
   /// apps-outline
-  static const IconData? apps_outline = IoniconsData(0xe922);
+  static const IconData apps_outline = IoniconsData(0xe922);
 
   /// apps-sharp
-  static const IconData? apps_sharp = IoniconsData(0xe923);
+  static const IconData apps_sharp = IoniconsData(0xe923);
 
   /// archive
-  static const IconData? archive = IoniconsData(0xe924);
+  static const IconData archive = IoniconsData(0xe924);
 
   /// archive-outline
-  static const IconData? archive_outline = IoniconsData(0xe925);
+  static const IconData archive_outline = IoniconsData(0xe925);
 
   /// archive-sharp
-  static const IconData? archive_sharp = IoniconsData(0xe926);
+  static const IconData archive_sharp = IoniconsData(0xe926);
 
   /// arrow-back
-  static const IconData? arrow_back = IoniconsData(0xe927);
+  static const IconData arrow_back = IoniconsData(0xe927);
 
   /// arrow-back-circle
-  static const IconData? arrow_back_circle = IoniconsData(0xe928);
+  static const IconData arrow_back_circle = IoniconsData(0xe928);
 
   /// arrow-back-circle-outline
-  static const IconData? arrow_back_circle_outline = IoniconsData(0xe929);
+  static const IconData arrow_back_circle_outline = IoniconsData(0xe929);
 
   /// arrow-back-circle-sharp
-  static const IconData? arrow_back_circle_sharp = IoniconsData(0xe92a);
+  static const IconData arrow_back_circle_sharp = IoniconsData(0xe92a);
 
   /// arrow-back-outline
-  static const IconData? arrow_back_outline = IoniconsData(0xe92b);
+  static const IconData arrow_back_outline = IoniconsData(0xe92b);
 
   /// arrow-back-sharp
-  static const IconData? arrow_back_sharp = IoniconsData(0xe92c);
+  static const IconData arrow_back_sharp = IoniconsData(0xe92c);
 
   /// arrow-down
-  static const IconData? arrow_down = IoniconsData(0xe92d);
+  static const IconData arrow_down = IoniconsData(0xe92d);
 
   /// arrow-down-circle
-  static const IconData? arrow_down_circle = IoniconsData(0xe92e);
+  static const IconData arrow_down_circle = IoniconsData(0xe92e);
 
   /// arrow-down-circle-outline
-  static const IconData? arrow_down_circle_outline = IoniconsData(0xe92f);
+  static const IconData arrow_down_circle_outline = IoniconsData(0xe92f);
 
   /// arrow-down-circle-sharp
-  static const IconData? arrow_down_circle_sharp = IoniconsData(0xe930);
+  static const IconData arrow_down_circle_sharp = IoniconsData(0xe930);
 
   /// arrow-down-outline
-  static const IconData? arrow_down_outline = IoniconsData(0xe931);
+  static const IconData arrow_down_outline = IoniconsData(0xe931);
 
   /// arrow-down-sharp
-  static const IconData? arrow_down_sharp = IoniconsData(0xe932);
+  static const IconData arrow_down_sharp = IoniconsData(0xe932);
 
   /// arrow-forward
-  static const IconData? arrow_forward = IoniconsData(0xe933);
+  static const IconData arrow_forward = IoniconsData(0xe933);
 
   /// arrow-forward-circle
-  static const IconData? arrow_forward_circle = IoniconsData(0xe934);
+  static const IconData arrow_forward_circle = IoniconsData(0xe934);
 
   /// arrow-forward-circle-outline
-  static const IconData? arrow_forward_circle_outline = IoniconsData(0xe935);
+  static const IconData arrow_forward_circle_outline = IoniconsData(0xe935);
 
   /// arrow-forward-circle-sharp
-  static const IconData? arrow_forward_circle_sharp = IoniconsData(0xe936);
+  static const IconData arrow_forward_circle_sharp = IoniconsData(0xe936);
 
   /// arrow-forward-outline
-  static const IconData? arrow_forward_outline = IoniconsData(0xe937);
+  static const IconData arrow_forward_outline = IoniconsData(0xe937);
 
   /// arrow-forward-sharp
-  static const IconData? arrow_forward_sharp = IoniconsData(0xe938);
+  static const IconData arrow_forward_sharp = IoniconsData(0xe938);
 
   /// arrow-redo
-  static const IconData? arrow_redo = IoniconsData(0xe939);
+  static const IconData arrow_redo = IoniconsData(0xe939);
 
   /// arrow-redo-circle
-  static const IconData? arrow_redo_circle = IoniconsData(0xe93a);
+  static const IconData arrow_redo_circle = IoniconsData(0xe93a);
 
   /// arrow-redo-circle-outline
-  static const IconData? arrow_redo_circle_outline = IoniconsData(0xe93b);
+  static const IconData arrow_redo_circle_outline = IoniconsData(0xe93b);
 
   /// arrow-redo-circle-sharp
-  static const IconData? arrow_redo_circle_sharp = IoniconsData(0xe93c);
+  static const IconData arrow_redo_circle_sharp = IoniconsData(0xe93c);
 
   /// arrow-redo-outline
-  static const IconData? arrow_redo_outline = IoniconsData(0xe93d);
+  static const IconData arrow_redo_outline = IoniconsData(0xe93d);
 
   /// arrow-redo-sharp
-  static const IconData? arrow_redo_sharp = IoniconsData(0xe93e);
+  static const IconData arrow_redo_sharp = IoniconsData(0xe93e);
 
   /// arrow-undo
-  static const IconData? arrow_undo = IoniconsData(0xe93f);
+  static const IconData arrow_undo = IoniconsData(0xe93f);
 
   /// arrow-undo-circle
-  static const IconData? arrow_undo_circle = IoniconsData(0xe940);
+  static const IconData arrow_undo_circle = IoniconsData(0xe940);
 
   /// arrow-undo-circle-outline
-  static const IconData? arrow_undo_circle_outline = IoniconsData(0xe941);
+  static const IconData arrow_undo_circle_outline = IoniconsData(0xe941);
 
   /// arrow-undo-circle-sharp
-  static const IconData? arrow_undo_circle_sharp = IoniconsData(0xe942);
+  static const IconData arrow_undo_circle_sharp = IoniconsData(0xe942);
 
   /// arrow-undo-outline
-  static const IconData? arrow_undo_outline = IoniconsData(0xe943);
+  static const IconData arrow_undo_outline = IoniconsData(0xe943);
 
   /// arrow-undo-sharp
-  static const IconData? arrow_undo_sharp = IoniconsData(0xe944);
+  static const IconData arrow_undo_sharp = IoniconsData(0xe944);
 
   /// arrow-up
-  static const IconData? arrow_up = IoniconsData(0xe945);
+  static const IconData arrow_up = IoniconsData(0xe945);
 
   /// arrow-up-circle
-  static const IconData? arrow_up_circle = IoniconsData(0xe946);
+  static const IconData arrow_up_circle = IoniconsData(0xe946);
 
   /// arrow-up-circle-outline
-  static const IconData? arrow_up_circle_outline = IoniconsData(0xe947);
+  static const IconData arrow_up_circle_outline = IoniconsData(0xe947);
 
   /// arrow-up-circle-sharp
-  static const IconData? arrow_up_circle_sharp = IoniconsData(0xe948);
+  static const IconData arrow_up_circle_sharp = IoniconsData(0xe948);
 
   /// arrow-up-outline
-  static const IconData? arrow_up_outline = IoniconsData(0xe949);
+  static const IconData arrow_up_outline = IoniconsData(0xe949);
 
   /// arrow-up-sharp
-  static const IconData? arrow_up_sharp = IoniconsData(0xe94a);
+  static const IconData arrow_up_sharp = IoniconsData(0xe94a);
 
   /// at
-  static const IconData? at = IoniconsData(0xe94b);
+  static const IconData at = IoniconsData(0xe94b);
 
   /// at-circle
-  static const IconData? at_circle = IoniconsData(0xe94c);
+  static const IconData at_circle = IoniconsData(0xe94c);
 
   /// at-circle-outline
-  static const IconData? at_circle_outline = IoniconsData(0xe94d);
+  static const IconData at_circle_outline = IoniconsData(0xe94d);
 
   /// at-circle-sharp
-  static const IconData? at_circle_sharp = IoniconsData(0xe94e);
+  static const IconData at_circle_sharp = IoniconsData(0xe94e);
 
   /// at-outline
-  static const IconData? at_outline = IoniconsData(0xe94f);
+  static const IconData at_outline = IoniconsData(0xe94f);
 
   /// at-sharp
-  static const IconData? at_sharp = IoniconsData(0xe950);
+  static const IconData at_sharp = IoniconsData(0xe950);
 
   /// attach
-  static const IconData? attach = IoniconsData(0xe951);
+  static const IconData attach = IoniconsData(0xe951);
 
   /// attach-outline
-  static const IconData? attach_outline = IoniconsData(0xe952);
+  static const IconData attach_outline = IoniconsData(0xe952);
 
   /// attach-sharp
-  static const IconData? attach_sharp = IoniconsData(0xe953);
+  static const IconData attach_sharp = IoniconsData(0xe953);
 
   /// backspace
-  static const IconData? backspace = IoniconsData(0xe954);
+  static const IconData backspace = IoniconsData(0xe954);
 
   /// backspace-outline
-  static const IconData? backspace_outline = IoniconsData(0xe955);
+  static const IconData backspace_outline = IoniconsData(0xe955);
 
   /// backspace-sharp
-  static const IconData? backspace_sharp = IoniconsData(0xe956);
+  static const IconData backspace_sharp = IoniconsData(0xe956);
 
   /// bag
-  static const IconData? bag = IoniconsData(0xe957);
+  static const IconData bag = IoniconsData(0xe957);
 
   /// bag-add
-  static const IconData? bag_add = IoniconsData(0xe958);
+  static const IconData bag_add = IoniconsData(0xe958);
 
   /// bag-add-outline
-  static const IconData? bag_add_outline = IoniconsData(0xe959);
+  static const IconData bag_add_outline = IoniconsData(0xe959);
 
   /// bag-add-sharp
-  static const IconData? bag_add_sharp = IoniconsData(0xe95a);
+  static const IconData bag_add_sharp = IoniconsData(0xe95a);
 
   /// bag-check
-  static const IconData? bag_check = IoniconsData(0xe95b);
+  static const IconData bag_check = IoniconsData(0xe95b);
 
   /// bag-check-outline
-  static const IconData? bag_check_outline = IoniconsData(0xe95c);
+  static const IconData bag_check_outline = IoniconsData(0xe95c);
 
   /// bag-check-sharp
-  static const IconData? bag_check_sharp = IoniconsData(0xe95d);
+  static const IconData bag_check_sharp = IoniconsData(0xe95d);
 
   /// bag-handle
-  static const IconData? bag_handle = IoniconsData(0xe95e);
+  static const IconData bag_handle = IoniconsData(0xe95e);
 
   /// bag-handle-outline
-  static const IconData? bag_handle_outline = IoniconsData(0xe95f);
+  static const IconData bag_handle_outline = IoniconsData(0xe95f);
 
   /// bag-handle-sharp
-  static const IconData? bag_handle_sharp = IoniconsData(0xe960);
+  static const IconData bag_handle_sharp = IoniconsData(0xe960);
 
   /// bag-outline
-  static const IconData? bag_outline = IoniconsData(0xe961);
+  static const IconData bag_outline = IoniconsData(0xe961);
 
   /// bag-remove
-  static const IconData? bag_remove = IoniconsData(0xe962);
+  static const IconData bag_remove = IoniconsData(0xe962);
 
   /// bag-remove-outline
-  static const IconData? bag_remove_outline = IoniconsData(0xe963);
+  static const IconData bag_remove_outline = IoniconsData(0xe963);
 
   /// bag-remove-sharp
-  static const IconData? bag_remove_sharp = IoniconsData(0xe964);
+  static const IconData bag_remove_sharp = IoniconsData(0xe964);
 
   /// bag-sharp
-  static const IconData? bag_sharp = IoniconsData(0xe965);
+  static const IconData bag_sharp = IoniconsData(0xe965);
 
   /// balloon
-  static const IconData? balloon = IoniconsData(0xe966);
+  static const IconData balloon = IoniconsData(0xe966);
 
   /// balloon-outline
-  static const IconData? balloon_outline = IoniconsData(0xe967);
+  static const IconData balloon_outline = IoniconsData(0xe967);
 
   /// balloon-sharp
-  static const IconData? balloon_sharp = IoniconsData(0xe968);
+  static const IconData balloon_sharp = IoniconsData(0xe968);
 
   /// ban
-  static const IconData? ban = IoniconsData(0xe969);
+  static const IconData ban = IoniconsData(0xe969);
 
   /// bandage
-  static const IconData? bandage = IoniconsData(0xe96a);
+  static const IconData bandage = IoniconsData(0xe96a);
 
   /// bandage-outline
-  static const IconData? bandage_outline = IoniconsData(0xe96b);
+  static const IconData bandage_outline = IoniconsData(0xe96b);
 
   /// bandage-sharp
-  static const IconData? bandage_sharp = IoniconsData(0xe96c);
+  static const IconData bandage_sharp = IoniconsData(0xe96c);
 
   /// ban-outline
-  static const IconData? ban_outline = IoniconsData(0xe96d);
+  static const IconData ban_outline = IoniconsData(0xe96d);
 
   /// ban-sharp
-  static const IconData? ban_sharp = IoniconsData(0xe96e);
+  static const IconData ban_sharp = IoniconsData(0xe96e);
 
   /// barbell
-  static const IconData? barbell = IoniconsData(0xe96f);
+  static const IconData barbell = IoniconsData(0xe96f);
 
   /// barbell-outline
-  static const IconData? barbell_outline = IoniconsData(0xe970);
+  static const IconData barbell_outline = IoniconsData(0xe970);
 
   /// barbell-sharp
-  static const IconData? barbell_sharp = IoniconsData(0xe971);
+  static const IconData barbell_sharp = IoniconsData(0xe971);
 
   /// bar-chart
-  static const IconData? bar_chart = IoniconsData(0xe972);
+  static const IconData bar_chart = IoniconsData(0xe972);
 
   /// bar-chart-outline
-  static const IconData? bar_chart_outline = IoniconsData(0xe973);
+  static const IconData bar_chart_outline = IoniconsData(0xe973);
 
   /// bar-chart-sharp
-  static const IconData? bar_chart_sharp = IoniconsData(0xe974);
+  static const IconData bar_chart_sharp = IoniconsData(0xe974);
 
   /// barcode
-  static const IconData? barcode = IoniconsData(0xe975);
+  static const IconData barcode = IoniconsData(0xe975);
 
   /// barcode-outline
-  static const IconData? barcode_outline = IoniconsData(0xe976);
+  static const IconData barcode_outline = IoniconsData(0xe976);
 
   /// barcode-sharp
-  static const IconData? barcode_sharp = IoniconsData(0xe977);
+  static const IconData barcode_sharp = IoniconsData(0xe977);
 
   /// baseball
-  static const IconData? baseball = IoniconsData(0xe978);
+  static const IconData baseball = IoniconsData(0xe978);
 
   /// baseball-outline
-  static const IconData? baseball_outline = IoniconsData(0xe979);
+  static const IconData baseball_outline = IoniconsData(0xe979);
 
   /// baseball-sharp
-  static const IconData? baseball_sharp = IoniconsData(0xe97a);
+  static const IconData baseball_sharp = IoniconsData(0xe97a);
 
   /// basket
-  static const IconData? basket = IoniconsData(0xe97b);
+  static const IconData basket = IoniconsData(0xe97b);
 
   /// basketball
-  static const IconData? basketball = IoniconsData(0xe97c);
+  static const IconData basketball = IoniconsData(0xe97c);
 
   /// basketball-outline
-  static const IconData? basketball_outline = IoniconsData(0xe97d);
+  static const IconData basketball_outline = IoniconsData(0xe97d);
 
   /// basketball-sharp
-  static const IconData? basketball_sharp = IoniconsData(0xe97e);
+  static const IconData basketball_sharp = IoniconsData(0xe97e);
 
   /// basket-outline
-  static const IconData? basket_outline = IoniconsData(0xe97f);
+  static const IconData basket_outline = IoniconsData(0xe97f);
 
   /// basket-sharp
-  static const IconData? basket_sharp = IoniconsData(0xe980);
+  static const IconData basket_sharp = IoniconsData(0xe980);
 
   /// battery-charging
-  static const IconData? battery_charging = IoniconsData(0xe981);
+  static const IconData battery_charging = IoniconsData(0xe981);
 
   /// battery-charging-outline
-  static const IconData? battery_charging_outline = IoniconsData(0xe982);
+  static const IconData battery_charging_outline = IoniconsData(0xe982);
 
   /// battery-charging-sharp
-  static const IconData? battery_charging_sharp = IoniconsData(0xe983);
+  static const IconData battery_charging_sharp = IoniconsData(0xe983);
 
   /// battery-dead
-  static const IconData? battery_dead = IoniconsData(0xe984);
+  static const IconData battery_dead = IoniconsData(0xe984);
 
   /// battery-dead-outline
-  static const IconData? battery_dead_outline = IoniconsData(0xe985);
+  static const IconData battery_dead_outline = IoniconsData(0xe985);
 
   /// battery-dead-sharp
-  static const IconData? battery_dead_sharp = IoniconsData(0xe986);
+  static const IconData battery_dead_sharp = IoniconsData(0xe986);
 
   /// battery-full
-  static const IconData? battery_full = IoniconsData(0xe987);
+  static const IconData battery_full = IoniconsData(0xe987);
 
   /// battery-full-outline
-  static const IconData? battery_full_outline = IoniconsData(0xe988);
+  static const IconData battery_full_outline = IoniconsData(0xe988);
 
   /// battery-full-sharp
-  static const IconData? battery_full_sharp = IoniconsData(0xe989);
+  static const IconData battery_full_sharp = IoniconsData(0xe989);
 
   /// battery-half
-  static const IconData? battery_half = IoniconsData(0xe98a);
+  static const IconData battery_half = IoniconsData(0xe98a);
 
   /// battery-half-outline
-  static const IconData? battery_half_outline = IoniconsData(0xe98b);
+  static const IconData battery_half_outline = IoniconsData(0xe98b);
 
   /// battery-half-sharp
-  static const IconData? battery_half_sharp = IoniconsData(0xe98c);
+  static const IconData battery_half_sharp = IoniconsData(0xe98c);
 
   /// beaker
-  static const IconData? beaker = IoniconsData(0xe98d);
+  static const IconData beaker = IoniconsData(0xe98d);
 
   /// beaker-outline
-  static const IconData? beaker_outline = IoniconsData(0xe98e);
+  static const IconData beaker_outline = IoniconsData(0xe98e);
 
   /// beaker-sharp
-  static const IconData? beaker_sharp = IoniconsData(0xe98f);
+  static const IconData beaker_sharp = IoniconsData(0xe98f);
 
   /// bed
-  static const IconData? bed = IoniconsData(0xe990);
+  static const IconData bed = IoniconsData(0xe990);
 
   /// bed-outline
-  static const IconData? bed_outline = IoniconsData(0xe991);
+  static const IconData bed_outline = IoniconsData(0xe991);
 
   /// bed-sharp
-  static const IconData? bed_sharp = IoniconsData(0xe992);
+  static const IconData bed_sharp = IoniconsData(0xe992);
 
   /// beer
-  static const IconData? beer = IoniconsData(0xe993);
+  static const IconData beer = IoniconsData(0xe993);
 
   /// beer-outline
-  static const IconData? beer_outline = IoniconsData(0xe994);
+  static const IconData beer_outline = IoniconsData(0xe994);
 
   /// beer-sharp
-  static const IconData? beer_sharp = IoniconsData(0xe995);
+  static const IconData beer_sharp = IoniconsData(0xe995);
 
   /// bicycle
-  static const IconData? bicycle = IoniconsData(0xe996);
+  static const IconData bicycle = IoniconsData(0xe996);
 
   /// bicycle-outline
-  static const IconData? bicycle_outline = IoniconsData(0xe997);
+  static const IconData bicycle_outline = IoniconsData(0xe997);
 
   /// bicycle-sharp
-  static const IconData? bicycle_sharp = IoniconsData(0xe998);
+  static const IconData bicycle_sharp = IoniconsData(0xe998);
 
   /// bluetooth
-  static const IconData? bluetooth = IoniconsData(0xe999);
+  static const IconData bluetooth = IoniconsData(0xe999);
 
   /// bluetooth-outline
-  static const IconData? bluetooth_outline = IoniconsData(0xe99a);
+  static const IconData bluetooth_outline = IoniconsData(0xe99a);
 
   /// bluetooth-sharp
-  static const IconData? bluetooth_sharp = IoniconsData(0xe99b);
+  static const IconData bluetooth_sharp = IoniconsData(0xe99b);
 
   /// boat
-  static const IconData? boat = IoniconsData(0xe99c);
+  static const IconData boat = IoniconsData(0xe99c);
 
   /// boat-outline
-  static const IconData? boat_outline = IoniconsData(0xe99d);
+  static const IconData boat_outline = IoniconsData(0xe99d);
 
   /// boat-sharp
-  static const IconData? boat_sharp = IoniconsData(0xe99e);
+  static const IconData boat_sharp = IoniconsData(0xe99e);
 
   /// body
-  static const IconData? body = IoniconsData(0xe99f);
+  static const IconData body = IoniconsData(0xe99f);
 
   /// body-outline
-  static const IconData? body_outline = IoniconsData(0xe9a0);
+  static const IconData body_outline = IoniconsData(0xe9a0);
 
   /// body-sharp
-  static const IconData? body_sharp = IoniconsData(0xe9a1);
+  static const IconData body_sharp = IoniconsData(0xe9a1);
 
   /// bonfire
-  static const IconData? bonfire = IoniconsData(0xe9a2);
+  static const IconData bonfire = IoniconsData(0xe9a2);
 
   /// bonfire-outline
-  static const IconData? bonfire_outline = IoniconsData(0xe9a3);
+  static const IconData bonfire_outline = IoniconsData(0xe9a3);
 
   /// bonfire-sharp
-  static const IconData? bonfire_sharp = IoniconsData(0xe9a4);
+  static const IconData bonfire_sharp = IoniconsData(0xe9a4);
 
   /// book
-  static const IconData? book = IoniconsData(0xe9a5);
+  static const IconData book = IoniconsData(0xe9a5);
 
   /// bookmark
-  static const IconData? bookmark = IoniconsData(0xe9a6);
+  static const IconData bookmark = IoniconsData(0xe9a6);
 
   /// bookmark-outline
-  static const IconData? bookmark_outline = IoniconsData(0xe9a7);
+  static const IconData bookmark_outline = IoniconsData(0xe9a7);
 
   /// bookmarks
-  static const IconData? bookmarks = IoniconsData(0xe9a8);
+  static const IconData bookmarks = IoniconsData(0xe9a8);
 
   /// bookmark-sharp
-  static const IconData? bookmark_sharp = IoniconsData(0xe9a9);
+  static const IconData bookmark_sharp = IoniconsData(0xe9a9);
 
   /// bookmarks-outline
-  static const IconData? bookmarks_outline = IoniconsData(0xe9aa);
+  static const IconData bookmarks_outline = IoniconsData(0xe9aa);
 
   /// bookmarks-sharp
-  static const IconData? bookmarks_sharp = IoniconsData(0xe9ab);
+  static const IconData bookmarks_sharp = IoniconsData(0xe9ab);
 
   /// book-outline
-  static const IconData? book_outline = IoniconsData(0xe9ac);
+  static const IconData book_outline = IoniconsData(0xe9ac);
 
   /// book-sharp
-  static const IconData? book_sharp = IoniconsData(0xe9ad);
+  static const IconData book_sharp = IoniconsData(0xe9ad);
 
   /// bowling-ball
-  static const IconData? bowling_ball = IoniconsData(0xe9ae);
+  static const IconData bowling_ball = IoniconsData(0xe9ae);
 
   /// bowling-ball-outline
-  static const IconData? bowling_ball_outline = IoniconsData(0xe9af);
+  static const IconData bowling_ball_outline = IoniconsData(0xe9af);
 
   /// bowling-ball-sharp
-  static const IconData? bowling_ball_sharp = IoniconsData(0xe9b0);
+  static const IconData bowling_ball_sharp = IoniconsData(0xe9b0);
 
   /// briefcase
-  static const IconData? briefcase = IoniconsData(0xe9b1);
+  static const IconData briefcase = IoniconsData(0xe9b1);
 
   /// briefcase-outline
-  static const IconData? briefcase_outline = IoniconsData(0xe9b2);
+  static const IconData briefcase_outline = IoniconsData(0xe9b2);
 
   /// briefcase-sharp
-  static const IconData? briefcase_sharp = IoniconsData(0xe9b3);
+  static const IconData briefcase_sharp = IoniconsData(0xe9b3);
 
   /// browsers
-  static const IconData? browsers = IoniconsData(0xe9b4);
+  static const IconData browsers = IoniconsData(0xe9b4);
 
   /// browsers-outline
-  static const IconData? browsers_outline = IoniconsData(0xe9b5);
+  static const IconData browsers_outline = IoniconsData(0xe9b5);
 
   /// browsers-sharp
-  static const IconData? browsers_sharp = IoniconsData(0xe9b6);
+  static const IconData browsers_sharp = IoniconsData(0xe9b6);
 
   /// brush
-  static const IconData? brush = IoniconsData(0xe9b7);
+  static const IconData brush = IoniconsData(0xe9b7);
 
   /// brush-outline
-  static const IconData? brush_outline = IoniconsData(0xe9b8);
+  static const IconData brush_outline = IoniconsData(0xe9b8);
 
   /// brush-sharp
-  static const IconData? brush_sharp = IoniconsData(0xe9b9);
+  static const IconData brush_sharp = IoniconsData(0xe9b9);
 
   /// bug
-  static const IconData? bug = IoniconsData(0xe9ba);
+  static const IconData bug = IoniconsData(0xe9ba);
 
   /// bug-outline
-  static const IconData? bug_outline = IoniconsData(0xe9bb);
+  static const IconData bug_outline = IoniconsData(0xe9bb);
 
   /// bug-sharp
-  static const IconData? bug_sharp = IoniconsData(0xe9bc);
+  static const IconData bug_sharp = IoniconsData(0xe9bc);
 
   /// build
-  static const IconData? build = IoniconsData(0xe9bd);
+  static const IconData build = IoniconsData(0xe9bd);
 
   /// build-outline
-  static const IconData? build_outline = IoniconsData(0xe9be);
+  static const IconData build_outline = IoniconsData(0xe9be);
 
   /// build-sharp
-  static const IconData? build_sharp = IoniconsData(0xe9bf);
+  static const IconData build_sharp = IoniconsData(0xe9bf);
 
   /// bulb
-  static const IconData? bulb = IoniconsData(0xe9c0);
+  static const IconData bulb = IoniconsData(0xe9c0);
 
   /// bulb-outline
-  static const IconData? bulb_outline = IoniconsData(0xe9c1);
+  static const IconData bulb_outline = IoniconsData(0xe9c1);
 
   /// bulb-sharp
-  static const IconData? bulb_sharp = IoniconsData(0xe9c2);
+  static const IconData bulb_sharp = IoniconsData(0xe9c2);
 
   /// bus
-  static const IconData? bus = IoniconsData(0xe9c3);
+  static const IconData bus = IoniconsData(0xe9c3);
 
   /// business
-  static const IconData? business = IoniconsData(0xe9c4);
+  static const IconData business = IoniconsData(0xe9c4);
 
   /// business-outline
-  static const IconData? business_outline = IoniconsData(0xe9c5);
+  static const IconData business_outline = IoniconsData(0xe9c5);
 
   /// business-sharp
-  static const IconData? business_sharp = IoniconsData(0xe9c6);
+  static const IconData business_sharp = IoniconsData(0xe9c6);
 
   /// bus-outline
-  static const IconData? bus_outline = IoniconsData(0xe9c7);
+  static const IconData bus_outline = IoniconsData(0xe9c7);
 
   /// bus-sharp
-  static const IconData? bus_sharp = IoniconsData(0xe9c8);
+  static const IconData bus_sharp = IoniconsData(0xe9c8);
 
   /// cafe
-  static const IconData? cafe = IoniconsData(0xe9c9);
+  static const IconData cafe = IoniconsData(0xe9c9);
 
   /// cafe-outline
-  static const IconData? cafe_outline = IoniconsData(0xe9ca);
+  static const IconData cafe_outline = IoniconsData(0xe9ca);
 
   /// cafe-sharp
-  static const IconData? cafe_sharp = IoniconsData(0xe9cb);
+  static const IconData cafe_sharp = IoniconsData(0xe9cb);
 
   /// calculator
-  static const IconData? calculator = IoniconsData(0xe9cc);
+  static const IconData calculator = IoniconsData(0xe9cc);
 
   /// calculator-outline
-  static const IconData? calculator_outline = IoniconsData(0xe9cd);
+  static const IconData calculator_outline = IoniconsData(0xe9cd);
 
   /// calculator-sharp
-  static const IconData? calculator_sharp = IoniconsData(0xe9ce);
+  static const IconData calculator_sharp = IoniconsData(0xe9ce);
 
   /// calendar
-  static const IconData? calendar = IoniconsData(0xe9cf);
+  static const IconData calendar = IoniconsData(0xe9cf);
 
   /// calendar-clear
-  static const IconData? calendar_clear = IoniconsData(0xe9d0);
+  static const IconData calendar_clear = IoniconsData(0xe9d0);
 
   /// calendar-clear-outline
-  static const IconData? calendar_clear_outline = IoniconsData(0xe9d1);
+  static const IconData calendar_clear_outline = IoniconsData(0xe9d1);
 
   /// calendar-clear-sharp
-  static const IconData? calendar_clear_sharp = IoniconsData(0xe9d2);
+  static const IconData calendar_clear_sharp = IoniconsData(0xe9d2);
 
   /// calendar-number
-  static const IconData? calendar_number = IoniconsData(0xe9d3);
+  static const IconData calendar_number = IoniconsData(0xe9d3);
 
   /// calendar-number-outline
-  static const IconData? calendar_number_outline = IoniconsData(0xe9d4);
+  static const IconData calendar_number_outline = IoniconsData(0xe9d4);
 
   /// calendar-number-sharp
-  static const IconData? calendar_number_sharp = IoniconsData(0xe9d5);
+  static const IconData calendar_number_sharp = IoniconsData(0xe9d5);
 
   /// calendar-outline
-  static const IconData? calendar_outline = IoniconsData(0xe9d6);
+  static const IconData calendar_outline = IoniconsData(0xe9d6);
 
   /// calendar-sharp
-  static const IconData? calendar_sharp = IoniconsData(0xe9d7);
+  static const IconData calendar_sharp = IoniconsData(0xe9d7);
 
   /// call
-  static const IconData? call = IoniconsData(0xe9d8);
+  static const IconData call = IoniconsData(0xe9d8);
 
   /// call-outline
-  static const IconData? call_outline = IoniconsData(0xe9d9);
+  static const IconData call_outline = IoniconsData(0xe9d9);
 
   /// call-sharp
-  static const IconData? call_sharp = IoniconsData(0xe9da);
+  static const IconData call_sharp = IoniconsData(0xe9da);
 
   /// camera
-  static const IconData? camera = IoniconsData(0xe9db);
+  static const IconData camera = IoniconsData(0xe9db);
 
   /// camera-outline
-  static const IconData? camera_outline = IoniconsData(0xe9dc);
+  static const IconData camera_outline = IoniconsData(0xe9dc);
 
   /// camera-reverse
-  static const IconData? camera_reverse = IoniconsData(0xe9dd);
+  static const IconData camera_reverse = IoniconsData(0xe9dd);
 
   /// camera-reverse-outline
-  static const IconData? camera_reverse_outline = IoniconsData(0xe9de);
+  static const IconData camera_reverse_outline = IoniconsData(0xe9de);
 
   /// camera-reverse-sharp
-  static const IconData? camera_reverse_sharp = IoniconsData(0xe9df);
+  static const IconData camera_reverse_sharp = IoniconsData(0xe9df);
 
   /// camera-sharp
-  static const IconData? camera_sharp = IoniconsData(0xe9e0);
+  static const IconData camera_sharp = IoniconsData(0xe9e0);
 
   /// car
-  static const IconData? car = IoniconsData(0xe9e1);
+  static const IconData car = IoniconsData(0xe9e1);
 
   /// card
-  static const IconData? card = IoniconsData(0xe9e2);
+  static const IconData card = IoniconsData(0xe9e2);
 
   /// card-outline
-  static const IconData? card_outline = IoniconsData(0xe9e3);
+  static const IconData card_outline = IoniconsData(0xe9e3);
 
   /// card-sharp
-  static const IconData? card_sharp = IoniconsData(0xe9e4);
+  static const IconData card_sharp = IoniconsData(0xe9e4);
 
   /// caret-back
-  static const IconData? caret_back = IoniconsData(0xe9e5);
+  static const IconData caret_back = IoniconsData(0xe9e5);
 
   /// caret-back-circle
-  static const IconData? caret_back_circle = IoniconsData(0xe9e6);
+  static const IconData caret_back_circle = IoniconsData(0xe9e6);
 
   /// caret-back-circle-outline
-  static const IconData? caret_back_circle_outline = IoniconsData(0xe9e7);
+  static const IconData caret_back_circle_outline = IoniconsData(0xe9e7);
 
   /// caret-back-circle-sharp
-  static const IconData? caret_back_circle_sharp = IoniconsData(0xe9e8);
+  static const IconData caret_back_circle_sharp = IoniconsData(0xe9e8);
 
   /// caret-back-outline
-  static const IconData? caret_back_outline = IoniconsData(0xe9e9);
+  static const IconData caret_back_outline = IoniconsData(0xe9e9);
 
   /// caret-back-sharp
-  static const IconData? caret_back_sharp = IoniconsData(0xe9ea);
+  static const IconData caret_back_sharp = IoniconsData(0xe9ea);
 
   /// caret-down
-  static const IconData? caret_down = IoniconsData(0xe9eb);
+  static const IconData caret_down = IoniconsData(0xe9eb);
 
   /// caret-down-circle
-  static const IconData? caret_down_circle = IoniconsData(0xe9ec);
+  static const IconData caret_down_circle = IoniconsData(0xe9ec);
 
   /// caret-down-circle-outline
-  static const IconData? caret_down_circle_outline = IoniconsData(0xe9ed);
+  static const IconData caret_down_circle_outline = IoniconsData(0xe9ed);
 
   /// caret-down-circle-sharp
-  static const IconData? caret_down_circle_sharp = IoniconsData(0xe9ee);
+  static const IconData caret_down_circle_sharp = IoniconsData(0xe9ee);
 
   /// caret-down-outline
-  static const IconData? caret_down_outline = IoniconsData(0xe9ef);
+  static const IconData caret_down_outline = IoniconsData(0xe9ef);
 
   /// caret-down-sharp
-  static const IconData? caret_down_sharp = IoniconsData(0xe9f0);
+  static const IconData caret_down_sharp = IoniconsData(0xe9f0);
 
   /// caret-forward
-  static const IconData? caret_forward = IoniconsData(0xe9f1);
+  static const IconData caret_forward = IoniconsData(0xe9f1);
 
   /// caret-forward-circle
-  static const IconData? caret_forward_circle = IoniconsData(0xe9f2);
+  static const IconData caret_forward_circle = IoniconsData(0xe9f2);
 
   /// caret-forward-circle-outline
-  static const IconData? caret_forward_circle_outline = IoniconsData(0xe9f3);
+  static const IconData caret_forward_circle_outline = IoniconsData(0xe9f3);
 
   /// caret-forward-circle-sharp
-  static const IconData? caret_forward_circle_sharp = IoniconsData(0xe9f4);
+  static const IconData caret_forward_circle_sharp = IoniconsData(0xe9f4);
 
   /// caret-forward-outline
-  static const IconData? caret_forward_outline = IoniconsData(0xe9f5);
+  static const IconData caret_forward_outline = IoniconsData(0xe9f5);
 
   /// caret-forward-sharp
-  static const IconData? caret_forward_sharp = IoniconsData(0xe9f6);
+  static const IconData caret_forward_sharp = IoniconsData(0xe9f6);
 
   /// caret-up
-  static const IconData? caret_up = IoniconsData(0xe9f7);
+  static const IconData caret_up = IoniconsData(0xe9f7);
 
   /// caret-up-circle
-  static const IconData? caret_up_circle = IoniconsData(0xe9f8);
+  static const IconData caret_up_circle = IoniconsData(0xe9f8);
 
   /// caret-up-circle-outline
-  static const IconData? caret_up_circle_outline = IoniconsData(0xe9f9);
+  static const IconData caret_up_circle_outline = IoniconsData(0xe9f9);
 
   /// caret-up-circle-sharp
-  static const IconData? caret_up_circle_sharp = IoniconsData(0xe9fa);
+  static const IconData caret_up_circle_sharp = IoniconsData(0xe9fa);
 
   /// caret-up-outline
-  static const IconData? caret_up_outline = IoniconsData(0xe9fb);
+  static const IconData caret_up_outline = IoniconsData(0xe9fb);
 
   /// caret-up-sharp
-  static const IconData? caret_up_sharp = IoniconsData(0xe9fc);
+  static const IconData caret_up_sharp = IoniconsData(0xe9fc);
 
   /// car-outline
-  static const IconData? car_outline = IoniconsData(0xe9fd);
+  static const IconData car_outline = IoniconsData(0xe9fd);
 
   /// car-sharp
-  static const IconData? car_sharp = IoniconsData(0xe9fe);
+  static const IconData car_sharp = IoniconsData(0xe9fe);
 
   /// car-sport
-  static const IconData? car_sport = IoniconsData(0xe9ff);
+  static const IconData car_sport = IoniconsData(0xe9ff);
 
   /// car-sport-outline
-  static const IconData? car_sport_outline = IoniconsData(0xea00);
+  static const IconData car_sport_outline = IoniconsData(0xea00);
 
   /// car-sport-sharp
-  static const IconData? car_sport_sharp = IoniconsData(0xea01);
+  static const IconData car_sport_sharp = IoniconsData(0xea01);
 
   /// cart
-  static const IconData? cart = IoniconsData(0xea02);
+  static const IconData cart = IoniconsData(0xea02);
 
   /// cart-outline
-  static const IconData? cart_outline = IoniconsData(0xea03);
+  static const IconData cart_outline = IoniconsData(0xea03);
 
   /// cart-sharp
-  static const IconData? cart_sharp = IoniconsData(0xea04);
+  static const IconData cart_sharp = IoniconsData(0xea04);
 
   /// cash
-  static const IconData? cash = IoniconsData(0xea05);
+  static const IconData cash = IoniconsData(0xea05);
 
   /// cash-outline
-  static const IconData? cash_outline = IoniconsData(0xea06);
+  static const IconData cash_outline = IoniconsData(0xea06);
 
   /// cash-sharp
-  static const IconData? cash_sharp = IoniconsData(0xea07);
+  static const IconData cash_sharp = IoniconsData(0xea07);
 
   /// cellular
-  static const IconData? cellular = IoniconsData(0xea08);
+  static const IconData cellular = IoniconsData(0xea08);
 
   /// cellular-outline
-  static const IconData? cellular_outline = IoniconsData(0xea09);
+  static const IconData cellular_outline = IoniconsData(0xea09);
 
   /// cellular-sharp
-  static const IconData? cellular_sharp = IoniconsData(0xea0a);
+  static const IconData cellular_sharp = IoniconsData(0xea0a);
 
   /// chatbox
-  static const IconData? chatbox = IoniconsData(0xea0b);
+  static const IconData chatbox = IoniconsData(0xea0b);
 
   /// chatbox-ellipses
-  static const IconData? chatbox_ellipses = IoniconsData(0xea0c);
+  static const IconData chatbox_ellipses = IoniconsData(0xea0c);
 
   /// chatbox-ellipses-outline
-  static const IconData? chatbox_ellipses_outline = IoniconsData(0xea0d);
+  static const IconData chatbox_ellipses_outline = IoniconsData(0xea0d);
 
   /// chatbox-ellipses-sharp
-  static const IconData? chatbox_ellipses_sharp = IoniconsData(0xea0e);
+  static const IconData chatbox_ellipses_sharp = IoniconsData(0xea0e);
 
   /// chatbox-outline
-  static const IconData? chatbox_outline = IoniconsData(0xea0f);
+  static const IconData chatbox_outline = IoniconsData(0xea0f);
 
   /// chatbox-sharp
-  static const IconData? chatbox_sharp = IoniconsData(0xea10);
+  static const IconData chatbox_sharp = IoniconsData(0xea10);
 
   /// chatbubble
-  static const IconData? chatbubble = IoniconsData(0xea11);
+  static const IconData chatbubble = IoniconsData(0xea11);
 
   /// chatbubble-ellipses
-  static const IconData? chatbubble_ellipses = IoniconsData(0xea12);
+  static const IconData chatbubble_ellipses = IoniconsData(0xea12);
 
   /// chatbubble-ellipses-outline
-  static const IconData? chatbubble_ellipses_outline = IoniconsData(0xea13);
+  static const IconData chatbubble_ellipses_outline = IoniconsData(0xea13);
 
   /// chatbubble-ellipses-sharp
-  static const IconData? chatbubble_ellipses_sharp = IoniconsData(0xea14);
+  static const IconData chatbubble_ellipses_sharp = IoniconsData(0xea14);
 
   /// chatbubble-outline
-  static const IconData? chatbubble_outline = IoniconsData(0xea15);
+  static const IconData chatbubble_outline = IoniconsData(0xea15);
 
   /// chatbubbles
-  static const IconData? chatbubbles = IoniconsData(0xea16);
+  static const IconData chatbubbles = IoniconsData(0xea16);
 
   /// chatbubble-sharp
-  static const IconData? chatbubble_sharp = IoniconsData(0xea17);
+  static const IconData chatbubble_sharp = IoniconsData(0xea17);
 
   /// chatbubbles-outline
-  static const IconData? chatbubbles_outline = IoniconsData(0xea18);
+  static const IconData chatbubbles_outline = IoniconsData(0xea18);
 
   /// chatbubbles-sharp
-  static const IconData? chatbubbles_sharp = IoniconsData(0xea19);
+  static const IconData chatbubbles_sharp = IoniconsData(0xea19);
 
   /// checkbox
-  static const IconData? checkbox = IoniconsData(0xea1a);
+  static const IconData checkbox = IoniconsData(0xea1a);
 
   /// checkbox-outline
-  static const IconData? checkbox_outline = IoniconsData(0xea1b);
+  static const IconData checkbox_outline = IoniconsData(0xea1b);
 
   /// checkbox-sharp
-  static const IconData? checkbox_sharp = IoniconsData(0xea1c);
+  static const IconData checkbox_sharp = IoniconsData(0xea1c);
 
   /// checkmark
-  static const IconData? checkmark = IoniconsData(0xea1d);
+  static const IconData checkmark = IoniconsData(0xea1d);
 
   /// checkmark-circle
-  static const IconData? checkmark_circle = IoniconsData(0xea1e);
+  static const IconData checkmark_circle = IoniconsData(0xea1e);
 
   /// checkmark-circle-outline
-  static const IconData? checkmark_circle_outline = IoniconsData(0xea1f);
+  static const IconData checkmark_circle_outline = IoniconsData(0xea1f);
 
   /// checkmark-circle-sharp
-  static const IconData? checkmark_circle_sharp = IoniconsData(0xea20);
+  static const IconData checkmark_circle_sharp = IoniconsData(0xea20);
 
   /// checkmark-done
-  static const IconData? checkmark_done = IoniconsData(0xea21);
+  static const IconData checkmark_done = IoniconsData(0xea21);
 
   /// checkmark-done-circle
-  static const IconData? checkmark_done_circle = IoniconsData(0xea22);
+  static const IconData checkmark_done_circle = IoniconsData(0xea22);
 
   /// checkmark-done-circle-outline
-  static const IconData? checkmark_done_circle_outline = IoniconsData(0xea23);
+  static const IconData checkmark_done_circle_outline = IoniconsData(0xea23);
 
   /// checkmark-done-circle-sharp
-  static const IconData? checkmark_done_circle_sharp = IoniconsData(0xea24);
+  static const IconData checkmark_done_circle_sharp = IoniconsData(0xea24);
 
   /// checkmark-done-outline
-  static const IconData? checkmark_done_outline = IoniconsData(0xea25);
+  static const IconData checkmark_done_outline = IoniconsData(0xea25);
 
   /// checkmark-done-sharp
-  static const IconData? checkmark_done_sharp = IoniconsData(0xea26);
+  static const IconData checkmark_done_sharp = IoniconsData(0xea26);
 
   /// checkmark-outline
-  static const IconData? checkmark_outline = IoniconsData(0xea27);
+  static const IconData checkmark_outline = IoniconsData(0xea27);
 
   /// checkmark-sharp
-  static const IconData? checkmark_sharp = IoniconsData(0xea28);
+  static const IconData checkmark_sharp = IoniconsData(0xea28);
 
   /// chevron-back
-  static const IconData? chevron_back = IoniconsData(0xea29);
+  static const IconData chevron_back = IoniconsData(0xea29);
 
   /// chevron-back-circle
-  static const IconData? chevron_back_circle = IoniconsData(0xea2a);
+  static const IconData chevron_back_circle = IoniconsData(0xea2a);
 
   /// chevron-back-circle-outline
-  static const IconData? chevron_back_circle_outline = IoniconsData(0xea2b);
+  static const IconData chevron_back_circle_outline = IoniconsData(0xea2b);
 
   /// chevron-back-circle-sharp
-  static const IconData? chevron_back_circle_sharp = IoniconsData(0xea2c);
+  static const IconData chevron_back_circle_sharp = IoniconsData(0xea2c);
 
   /// chevron-back-outline
-  static const IconData? chevron_back_outline = IoniconsData(0xea2d);
+  static const IconData chevron_back_outline = IoniconsData(0xea2d);
 
   /// chevron-back-sharp
-  static const IconData? chevron_back_sharp = IoniconsData(0xea2e);
+  static const IconData chevron_back_sharp = IoniconsData(0xea2e);
 
   /// chevron-down
-  static const IconData? chevron_down = IoniconsData(0xea2f);
+  static const IconData chevron_down = IoniconsData(0xea2f);
 
   /// chevron-down-circle
-  static const IconData? chevron_down_circle = IoniconsData(0xea30);
+  static const IconData chevron_down_circle = IoniconsData(0xea30);
 
   /// chevron-down-circle-outline
-  static const IconData? chevron_down_circle_outline = IoniconsData(0xea31);
+  static const IconData chevron_down_circle_outline = IoniconsData(0xea31);
 
   /// chevron-down-circle-sharp
-  static const IconData? chevron_down_circle_sharp = IoniconsData(0xea32);
+  static const IconData chevron_down_circle_sharp = IoniconsData(0xea32);
 
   /// chevron-down-outline
-  static const IconData? chevron_down_outline = IoniconsData(0xea33);
+  static const IconData chevron_down_outline = IoniconsData(0xea33);
 
   /// chevron-down-sharp
-  static const IconData? chevron_down_sharp = IoniconsData(0xea34);
+  static const IconData chevron_down_sharp = IoniconsData(0xea34);
 
   /// chevron-forward
-  static const IconData? chevron_forward = IoniconsData(0xea35);
+  static const IconData chevron_forward = IoniconsData(0xea35);
 
   /// chevron-forward-circle
-  static const IconData? chevron_forward_circle = IoniconsData(0xea36);
+  static const IconData chevron_forward_circle = IoniconsData(0xea36);
 
   /// chevron-forward-circle-outline
-  static const IconData? chevron_forward_circle_outline = IoniconsData(0xea37);
+  static const IconData chevron_forward_circle_outline = IoniconsData(0xea37);
 
   /// chevron-forward-circle-sharp
-  static const IconData? chevron_forward_circle_sharp = IoniconsData(0xea38);
+  static const IconData chevron_forward_circle_sharp = IoniconsData(0xea38);
 
   /// chevron-forward-outline
-  static const IconData? chevron_forward_outline = IoniconsData(0xea39);
+  static const IconData chevron_forward_outline = IoniconsData(0xea39);
 
   /// chevron-forward-sharp
-  static const IconData? chevron_forward_sharp = IoniconsData(0xea3a);
+  static const IconData chevron_forward_sharp = IoniconsData(0xea3a);
 
   /// chevron-up
-  static const IconData? chevron_up = IoniconsData(0xea3b);
+  static const IconData chevron_up = IoniconsData(0xea3b);
 
   /// chevron-up-circle
-  static const IconData? chevron_up_circle = IoniconsData(0xea3c);
+  static const IconData chevron_up_circle = IoniconsData(0xea3c);
 
   /// chevron-up-circle-outline
-  static const IconData? chevron_up_circle_outline = IoniconsData(0xea3d);
+  static const IconData chevron_up_circle_outline = IoniconsData(0xea3d);
 
   /// chevron-up-circle-sharp
-  static const IconData? chevron_up_circle_sharp = IoniconsData(0xea3e);
+  static const IconData chevron_up_circle_sharp = IoniconsData(0xea3e);
 
   /// chevron-up-outline
-  static const IconData? chevron_up_outline = IoniconsData(0xea3f);
+  static const IconData chevron_up_outline = IoniconsData(0xea3f);
 
   /// chevron-up-sharp
-  static const IconData? chevron_up_sharp = IoniconsData(0xea40);
+  static const IconData chevron_up_sharp = IoniconsData(0xea40);
 
   /// clipboard
-  static const IconData? clipboard = IoniconsData(0xea41);
+  static const IconData clipboard = IoniconsData(0xea41);
 
   /// clipboard-outline
-  static const IconData? clipboard_outline = IoniconsData(0xea42);
+  static const IconData clipboard_outline = IoniconsData(0xea42);
 
   /// clipboard-sharp
-  static const IconData? clipboard_sharp = IoniconsData(0xea43);
+  static const IconData clipboard_sharp = IoniconsData(0xea43);
 
   /// close
-  static const IconData? close = IoniconsData(0xea44);
+  static const IconData close = IoniconsData(0xea44);
 
   /// close-circle
-  static const IconData? close_circle = IoniconsData(0xea45);
+  static const IconData close_circle = IoniconsData(0xea45);
 
   /// close-circle-outline
-  static const IconData? close_circle_outline = IoniconsData(0xea46);
+  static const IconData close_circle_outline = IoniconsData(0xea46);
 
   /// close-circle-sharp
-  static const IconData? close_circle_sharp = IoniconsData(0xea47);
+  static const IconData close_circle_sharp = IoniconsData(0xea47);
 
   /// close-outline
-  static const IconData? close_outline = IoniconsData(0xea48);
+  static const IconData close_outline = IoniconsData(0xea48);
 
   /// close-sharp
-  static const IconData? close_sharp = IoniconsData(0xea49);
+  static const IconData close_sharp = IoniconsData(0xea49);
 
   /// cloud
-  static const IconData? cloud = IoniconsData(0xea4a);
+  static const IconData cloud = IoniconsData(0xea4a);
 
   /// cloud-circle
-  static const IconData? cloud_circle = IoniconsData(0xea4b);
+  static const IconData cloud_circle = IoniconsData(0xea4b);
 
   /// cloud-circle-outline
-  static const IconData? cloud_circle_outline = IoniconsData(0xea4c);
+  static const IconData cloud_circle_outline = IoniconsData(0xea4c);
 
   /// cloud-circle-sharp
-  static const IconData? cloud_circle_sharp = IoniconsData(0xea4d);
+  static const IconData cloud_circle_sharp = IoniconsData(0xea4d);
 
   /// cloud-done
-  static const IconData? cloud_done = IoniconsData(0xea4e);
+  static const IconData cloud_done = IoniconsData(0xea4e);
 
   /// cloud-done-outline
-  static const IconData? cloud_done_outline = IoniconsData(0xea4f);
+  static const IconData cloud_done_outline = IoniconsData(0xea4f);
 
   /// cloud-done-sharp
-  static const IconData? cloud_done_sharp = IoniconsData(0xea50);
+  static const IconData cloud_done_sharp = IoniconsData(0xea50);
 
   /// cloud-download
-  static const IconData? cloud_download = IoniconsData(0xea51);
+  static const IconData cloud_download = IoniconsData(0xea51);
 
   /// cloud-download-outline
-  static const IconData? cloud_download_outline = IoniconsData(0xea52);
+  static const IconData cloud_download_outline = IoniconsData(0xea52);
 
   /// cloud-download-sharp
-  static const IconData? cloud_download_sharp = IoniconsData(0xea53);
+  static const IconData cloud_download_sharp = IoniconsData(0xea53);
 
   /// cloud-offline
-  static const IconData? cloud_offline = IoniconsData(0xea54);
+  static const IconData cloud_offline = IoniconsData(0xea54);
 
   /// cloud-offline-outline
-  static const IconData? cloud_offline_outline = IoniconsData(0xea55);
+  static const IconData cloud_offline_outline = IoniconsData(0xea55);
 
   /// cloud-offline-sharp
-  static const IconData? cloud_offline_sharp = IoniconsData(0xea56);
+  static const IconData cloud_offline_sharp = IoniconsData(0xea56);
 
   /// cloud-outline
-  static const IconData? cloud_outline = IoniconsData(0xea57);
+  static const IconData cloud_outline = IoniconsData(0xea57);
 
   /// cloud-sharp
-  static const IconData? cloud_sharp = IoniconsData(0xea58);
+  static const IconData cloud_sharp = IoniconsData(0xea58);
 
   /// cloud-upload
-  static const IconData? cloud_upload = IoniconsData(0xea59);
+  static const IconData cloud_upload = IoniconsData(0xea59);
 
   /// cloud-upload-outline
-  static const IconData? cloud_upload_outline = IoniconsData(0xea5a);
+  static const IconData cloud_upload_outline = IoniconsData(0xea5a);
 
   /// cloud-upload-sharp
-  static const IconData? cloud_upload_sharp = IoniconsData(0xea5b);
+  static const IconData cloud_upload_sharp = IoniconsData(0xea5b);
 
   /// cloudy
-  static const IconData? cloudy = IoniconsData(0xea5c);
+  static const IconData cloudy = IoniconsData(0xea5c);
 
   /// cloudy-night
-  static const IconData? cloudy_night = IoniconsData(0xea5d);
+  static const IconData cloudy_night = IoniconsData(0xea5d);
 
   /// cloudy-night-outline
-  static const IconData? cloudy_night_outline = IoniconsData(0xea5e);
+  static const IconData cloudy_night_outline = IoniconsData(0xea5e);
 
   /// cloudy-night-sharp
-  static const IconData? cloudy_night_sharp = IoniconsData(0xea5f);
+  static const IconData cloudy_night_sharp = IoniconsData(0xea5f);
 
   /// cloudy-outline
-  static const IconData? cloudy_outline = IoniconsData(0xea60);
+  static const IconData cloudy_outline = IoniconsData(0xea60);
 
   /// cloudy-sharp
-  static const IconData? cloudy_sharp = IoniconsData(0xea61);
+  static const IconData cloudy_sharp = IoniconsData(0xea61);
 
   /// code
-  static const IconData? code = IoniconsData(0xea62);
+  static const IconData code = IoniconsData(0xea62);
 
   /// code-download
-  static const IconData? code_download = IoniconsData(0xea63);
+  static const IconData code_download = IoniconsData(0xea63);
 
   /// code-download-outline
-  static const IconData? code_download_outline = IoniconsData(0xea64);
+  static const IconData code_download_outline = IoniconsData(0xea64);
 
   /// code-download-sharp
-  static const IconData? code_download_sharp = IoniconsData(0xea65);
+  static const IconData code_download_sharp = IoniconsData(0xea65);
 
   /// code-outline
-  static const IconData? code_outline = IoniconsData(0xea66);
+  static const IconData code_outline = IoniconsData(0xea66);
 
   /// code-sharp
-  static const IconData? code_sharp = IoniconsData(0xea67);
+  static const IconData code_sharp = IoniconsData(0xea67);
 
   /// code-slash
-  static const IconData? code_slash = IoniconsData(0xea68);
+  static const IconData code_slash = IoniconsData(0xea68);
 
   /// code-slash-outline
-  static const IconData? code_slash_outline = IoniconsData(0xea69);
+  static const IconData code_slash_outline = IoniconsData(0xea69);
 
   /// code-slash-sharp
-  static const IconData? code_slash_sharp = IoniconsData(0xea6a);
+  static const IconData code_slash_sharp = IoniconsData(0xea6a);
 
   /// code-working
-  static const IconData? code_working = IoniconsData(0xea6b);
+  static const IconData code_working = IoniconsData(0xea6b);
 
   /// code-working-outline
-  static const IconData? code_working_outline = IoniconsData(0xea6c);
+  static const IconData code_working_outline = IoniconsData(0xea6c);
 
   /// code-working-sharp
-  static const IconData? code_working_sharp = IoniconsData(0xea6d);
+  static const IconData code_working_sharp = IoniconsData(0xea6d);
 
   /// cog
-  static const IconData? cog = IoniconsData(0xea6e);
+  static const IconData cog = IoniconsData(0xea6e);
 
   /// cog-outline
-  static const IconData? cog_outline = IoniconsData(0xea6f);
+  static const IconData cog_outline = IoniconsData(0xea6f);
 
   /// cog-sharp
-  static const IconData? cog_sharp = IoniconsData(0xea70);
+  static const IconData cog_sharp = IoniconsData(0xea70);
 
   /// color-fill
-  static const IconData? color_fill = IoniconsData(0xea71);
+  static const IconData color_fill = IoniconsData(0xea71);
 
   /// color-fill-outline
-  static const IconData? color_fill_outline = IoniconsData(0xea72);
+  static const IconData color_fill_outline = IoniconsData(0xea72);
 
   /// color-fill-sharp
-  static const IconData? color_fill_sharp = IoniconsData(0xea73);
+  static const IconData color_fill_sharp = IoniconsData(0xea73);
 
   /// color-filter
-  static const IconData? color_filter = IoniconsData(0xea74);
+  static const IconData color_filter = IoniconsData(0xea74);
 
   /// color-filter-outline
-  static const IconData? color_filter_outline = IoniconsData(0xea75);
+  static const IconData color_filter_outline = IoniconsData(0xea75);
 
   /// color-filter-sharp
-  static const IconData? color_filter_sharp = IoniconsData(0xea76);
+  static const IconData color_filter_sharp = IoniconsData(0xea76);
 
   /// color-palette
-  static const IconData? color_palette = IoniconsData(0xea77);
+  static const IconData color_palette = IoniconsData(0xea77);
 
   /// color-palette-outline
-  static const IconData? color_palette_outline = IoniconsData(0xea78);
+  static const IconData color_palette_outline = IoniconsData(0xea78);
 
   /// color-palette-sharp
-  static const IconData? color_palette_sharp = IoniconsData(0xea79);
+  static const IconData color_palette_sharp = IoniconsData(0xea79);
 
   /// color-wand
-  static const IconData? color_wand = IoniconsData(0xea7a);
+  static const IconData color_wand = IoniconsData(0xea7a);
 
   /// color-wand-outline
-  static const IconData? color_wand_outline = IoniconsData(0xea7b);
+  static const IconData color_wand_outline = IoniconsData(0xea7b);
 
   /// color-wand-sharp
-  static const IconData? color_wand_sharp = IoniconsData(0xea7c);
+  static const IconData color_wand_sharp = IoniconsData(0xea7c);
 
   /// compass
-  static const IconData? compass = IoniconsData(0xea7d);
+  static const IconData compass = IoniconsData(0xea7d);
 
   /// compass-outline
-  static const IconData? compass_outline = IoniconsData(0xea7e);
+  static const IconData compass_outline = IoniconsData(0xea7e);
 
   /// compass-sharp
-  static const IconData? compass_sharp = IoniconsData(0xea7f);
+  static const IconData compass_sharp = IoniconsData(0xea7f);
 
   /// construct
-  static const IconData? construct = IoniconsData(0xea80);
+  static const IconData construct = IoniconsData(0xea80);
 
   /// construct-outline
-  static const IconData? construct_outline = IoniconsData(0xea81);
+  static const IconData construct_outline = IoniconsData(0xea81);
 
   /// construct-sharp
-  static const IconData? construct_sharp = IoniconsData(0xea82);
+  static const IconData construct_sharp = IoniconsData(0xea82);
 
   /// contract
-  static const IconData? contract = IoniconsData(0xea83);
+  static const IconData contract = IoniconsData(0xea83);
 
   /// contract-outline
-  static const IconData? contract_outline = IoniconsData(0xea84);
+  static const IconData contract_outline = IoniconsData(0xea84);
 
   /// contract-sharp
-  static const IconData? contract_sharp = IoniconsData(0xea85);
+  static const IconData contract_sharp = IoniconsData(0xea85);
 
   /// contrast
-  static const IconData? contrast = IoniconsData(0xea86);
+  static const IconData contrast = IoniconsData(0xea86);
 
   /// contrast-outline
-  static const IconData? contrast_outline = IoniconsData(0xea87);
+  static const IconData contrast_outline = IoniconsData(0xea87);
 
   /// contrast-sharp
-  static const IconData? contrast_sharp = IoniconsData(0xea88);
+  static const IconData contrast_sharp = IoniconsData(0xea88);
 
   /// copy
-  static const IconData? copy = IoniconsData(0xea89);
+  static const IconData copy = IoniconsData(0xea89);
 
   /// copy-outline
-  static const IconData? copy_outline = IoniconsData(0xea8a);
+  static const IconData copy_outline = IoniconsData(0xea8a);
 
   /// copy-sharp
-  static const IconData? copy_sharp = IoniconsData(0xea8b);
+  static const IconData copy_sharp = IoniconsData(0xea8b);
 
   /// create
-  static const IconData? create = IoniconsData(0xea8c);
+  static const IconData create = IoniconsData(0xea8c);
 
   /// create-outline
-  static const IconData? create_outline = IoniconsData(0xea8d);
+  static const IconData create_outline = IoniconsData(0xea8d);
 
   /// create-sharp
-  static const IconData? create_sharp = IoniconsData(0xea8e);
+  static const IconData create_sharp = IoniconsData(0xea8e);
 
   /// crop
-  static const IconData? crop = IoniconsData(0xea8f);
+  static const IconData crop = IoniconsData(0xea8f);
 
   /// crop-outline
-  static const IconData? crop_outline = IoniconsData(0xea90);
+  static const IconData crop_outline = IoniconsData(0xea90);
 
   /// crop-sharp
-  static const IconData? crop_sharp = IoniconsData(0xea91);
+  static const IconData crop_sharp = IoniconsData(0xea91);
 
   /// cube
-  static const IconData? cube = IoniconsData(0xea92);
+  static const IconData cube = IoniconsData(0xea92);
 
   /// cube-outline
-  static const IconData? cube_outline = IoniconsData(0xea93);
+  static const IconData cube_outline = IoniconsData(0xea93);
 
   /// cube-sharp
-  static const IconData? cube_sharp = IoniconsData(0xea94);
+  static const IconData cube_sharp = IoniconsData(0xea94);
 
   /// cut
-  static const IconData? cut = IoniconsData(0xea95);
+  static const IconData cut = IoniconsData(0xea95);
 
   /// cut-outline
-  static const IconData? cut_outline = IoniconsData(0xea96);
+  static const IconData cut_outline = IoniconsData(0xea96);
 
   /// cut-sharp
-  static const IconData? cut_sharp = IoniconsData(0xea97);
+  static const IconData cut_sharp = IoniconsData(0xea97);
 
   /// desktop
-  static const IconData? desktop = IoniconsData(0xea98);
+  static const IconData desktop = IoniconsData(0xea98);
 
   /// desktop-outline
-  static const IconData? desktop_outline = IoniconsData(0xea99);
+  static const IconData desktop_outline = IoniconsData(0xea99);
 
   /// desktop-sharp
-  static const IconData? desktop_sharp = IoniconsData(0xea9a);
+  static const IconData desktop_sharp = IoniconsData(0xea9a);
 
   /// diamond
-  static const IconData? diamond = IoniconsData(0xea9b);
+  static const IconData diamond = IoniconsData(0xea9b);
 
   /// diamond-outline
-  static const IconData? diamond_outline = IoniconsData(0xea9c);
+  static const IconData diamond_outline = IoniconsData(0xea9c);
 
   /// diamond-sharp
-  static const IconData? diamond_sharp = IoniconsData(0xea9d);
+  static const IconData diamond_sharp = IoniconsData(0xea9d);
 
   /// dice
-  static const IconData? dice = IoniconsData(0xea9e);
+  static const IconData dice = IoniconsData(0xea9e);
 
   /// dice-outline
-  static const IconData? dice_outline = IoniconsData(0xea9f);
+  static const IconData dice_outline = IoniconsData(0xea9f);
 
   /// dice-sharp
-  static const IconData? dice_sharp = IoniconsData(0xeaa0);
+  static const IconData dice_sharp = IoniconsData(0xeaa0);
 
   /// disc
-  static const IconData? disc = IoniconsData(0xeaa1);
+  static const IconData disc = IoniconsData(0xeaa1);
 
   /// disc-outline
-  static const IconData? disc_outline = IoniconsData(0xeaa2);
+  static const IconData disc_outline = IoniconsData(0xeaa2);
 
   /// disc-sharp
-  static const IconData? disc_sharp = IoniconsData(0xeaa3);
+  static const IconData disc_sharp = IoniconsData(0xeaa3);
 
   /// document
-  static const IconData? document = IoniconsData(0xeaa4);
+  static const IconData document = IoniconsData(0xeaa4);
 
   /// document-attach
-  static const IconData? document_attach = IoniconsData(0xeaa5);
+  static const IconData document_attach = IoniconsData(0xeaa5);
 
   /// document-attach-outline
-  static const IconData? document_attach_outline = IoniconsData(0xeaa6);
+  static const IconData document_attach_outline = IoniconsData(0xeaa6);
 
   /// document-attach-sharp
-  static const IconData? document_attach_sharp = IoniconsData(0xeaa7);
+  static const IconData document_attach_sharp = IoniconsData(0xeaa7);
 
   /// document-lock
-  static const IconData? document_lock = IoniconsData(0xeaa8);
+  static const IconData document_lock = IoniconsData(0xeaa8);
 
   /// document-lock-outline
-  static const IconData? document_lock_outline = IoniconsData(0xeaa9);
+  static const IconData document_lock_outline = IoniconsData(0xeaa9);
 
   /// document-lock-sharp
-  static const IconData? document_lock_sharp = IoniconsData(0xeaaa);
+  static const IconData document_lock_sharp = IoniconsData(0xeaaa);
 
   /// document-outline
-  static const IconData? document_outline = IoniconsData(0xeaab);
+  static const IconData document_outline = IoniconsData(0xeaab);
 
   /// documents
-  static const IconData? documents = IoniconsData(0xeaac);
+  static const IconData documents = IoniconsData(0xeaac);
 
   /// document-sharp
-  static const IconData? document_sharp = IoniconsData(0xeaad);
+  static const IconData document_sharp = IoniconsData(0xeaad);
 
   /// documents-outline
-  static const IconData? documents_outline = IoniconsData(0xeaae);
+  static const IconData documents_outline = IoniconsData(0xeaae);
 
   /// documents-sharp
-  static const IconData? documents_sharp = IoniconsData(0xeaaf);
+  static const IconData documents_sharp = IoniconsData(0xeaaf);
 
   /// document-text
-  static const IconData? document_text = IoniconsData(0xeab0);
+  static const IconData document_text = IoniconsData(0xeab0);
 
   /// document-text-outline
-  static const IconData? document_text_outline = IoniconsData(0xeab1);
+  static const IconData document_text_outline = IoniconsData(0xeab1);
 
   /// document-text-sharp
-  static const IconData? document_text_sharp = IoniconsData(0xeab2);
+  static const IconData document_text_sharp = IoniconsData(0xeab2);
 
   /// download
-  static const IconData? download = IoniconsData(0xeab3);
+  static const IconData download = IoniconsData(0xeab3);
 
   /// download-outline
-  static const IconData? download_outline = IoniconsData(0xeab4);
+  static const IconData download_outline = IoniconsData(0xeab4);
 
   /// download-sharp
-  static const IconData? download_sharp = IoniconsData(0xeab5);
+  static const IconData download_sharp = IoniconsData(0xeab5);
 
   /// duplicate
-  static const IconData? duplicate = IoniconsData(0xeab6);
+  static const IconData duplicate = IoniconsData(0xeab6);
 
   /// duplicate-outline
-  static const IconData? duplicate_outline = IoniconsData(0xeab7);
+  static const IconData duplicate_outline = IoniconsData(0xeab7);
 
   /// duplicate-sharp
-  static const IconData? duplicate_sharp = IoniconsData(0xeab8);
+  static const IconData duplicate_sharp = IoniconsData(0xeab8);
 
   /// ear
-  static const IconData? ear = IoniconsData(0xeab9);
+  static const IconData ear = IoniconsData(0xeab9);
 
   /// ear-outline
-  static const IconData? ear_outline = IoniconsData(0xeaba);
+  static const IconData ear_outline = IoniconsData(0xeaba);
 
   /// ear-sharp
-  static const IconData? ear_sharp = IoniconsData(0xeabb);
+  static const IconData ear_sharp = IoniconsData(0xeabb);
 
   /// earth
-  static const IconData? earth = IoniconsData(0xeabc);
+  static const IconData earth = IoniconsData(0xeabc);
 
   /// earth-outline
-  static const IconData? earth_outline = IoniconsData(0xeabd);
+  static const IconData earth_outline = IoniconsData(0xeabd);
 
   /// earth-sharp
-  static const IconData? earth_sharp = IoniconsData(0xeabe);
+  static const IconData earth_sharp = IoniconsData(0xeabe);
 
   /// easel
-  static const IconData? easel = IoniconsData(0xeabf);
+  static const IconData easel = IoniconsData(0xeabf);
 
   /// easel-outline
-  static const IconData? easel_outline = IoniconsData(0xeac0);
+  static const IconData easel_outline = IoniconsData(0xeac0);
 
   /// easel-sharp
-  static const IconData? easel_sharp = IoniconsData(0xeac1);
+  static const IconData easel_sharp = IoniconsData(0xeac1);
 
   /// egg
-  static const IconData? egg = IoniconsData(0xeac2);
+  static const IconData egg = IoniconsData(0xeac2);
 
   /// egg-outline
-  static const IconData? egg_outline = IoniconsData(0xeac3);
+  static const IconData egg_outline = IoniconsData(0xeac3);
 
   /// egg-sharp
-  static const IconData? egg_sharp = IoniconsData(0xeac4);
+  static const IconData egg_sharp = IoniconsData(0xeac4);
 
   /// ellipse
-  static const IconData? ellipse = IoniconsData(0xeac5);
+  static const IconData ellipse = IoniconsData(0xeac5);
 
   /// ellipse-outline
-  static const IconData? ellipse_outline = IoniconsData(0xeac6);
+  static const IconData ellipse_outline = IoniconsData(0xeac6);
 
   /// ellipse-sharp
-  static const IconData? ellipse_sharp = IoniconsData(0xeac7);
+  static const IconData ellipse_sharp = IoniconsData(0xeac7);
 
   /// ellipsis-horizontal
-  static const IconData? ellipsis_horizontal = IoniconsData(0xeac8);
+  static const IconData ellipsis_horizontal = IoniconsData(0xeac8);
 
   /// ellipsis-horizontal-circle
-  static const IconData? ellipsis_horizontal_circle = IoniconsData(0xeac9);
+  static const IconData ellipsis_horizontal_circle = IoniconsData(0xeac9);
 
   /// ellipsis-horizontal-circle-outline
-  static const IconData? ellipsis_horizontal_circle_outline =
+  static const IconData ellipsis_horizontal_circle_outline =
       IoniconsData(0xeaca);
 
   /// ellipsis-horizontal-circle-sharp
-  static const IconData? ellipsis_horizontal_circle_sharp = IoniconsData(0xeacb);
+  static const IconData ellipsis_horizontal_circle_sharp = IoniconsData(0xeacb);
 
   /// ellipsis-horizontal-outline
-  static const IconData? ellipsis_horizontal_outline = IoniconsData(0xeacc);
+  static const IconData ellipsis_horizontal_outline = IoniconsData(0xeacc);
 
   /// ellipsis-horizontal-sharp
-  static const IconData? ellipsis_horizontal_sharp = IoniconsData(0xeacd);
+  static const IconData ellipsis_horizontal_sharp = IoniconsData(0xeacd);
 
   /// ellipsis-vertical
-  static const IconData? ellipsis_vertical = IoniconsData(0xeace);
+  static const IconData ellipsis_vertical = IoniconsData(0xeace);
 
   /// ellipsis-vertical-circle
-  static const IconData? ellipsis_vertical_circle = IoniconsData(0xeacf);
+  static const IconData ellipsis_vertical_circle = IoniconsData(0xeacf);
 
   /// ellipsis-vertical-circle-outline
-  static const IconData? ellipsis_vertical_circle_outline = IoniconsData(0xead0);
+  static const IconData ellipsis_vertical_circle_outline = IoniconsData(0xead0);
 
   /// ellipsis-vertical-circle-sharp
-  static const IconData? ellipsis_vertical_circle_sharp = IoniconsData(0xead1);
+  static const IconData ellipsis_vertical_circle_sharp = IoniconsData(0xead1);
 
   /// ellipsis-vertical-outline
-  static const IconData? ellipsis_vertical_outline = IoniconsData(0xead2);
+  static const IconData ellipsis_vertical_outline = IoniconsData(0xead2);
 
   /// ellipsis-vertical-sharp
-  static const IconData? ellipsis_vertical_sharp = IoniconsData(0xead3);
+  static const IconData ellipsis_vertical_sharp = IoniconsData(0xead3);
 
   /// enter
-  static const IconData? enter = IoniconsData(0xead4);
+  static const IconData enter = IoniconsData(0xead4);
 
   /// enter-outline
-  static const IconData? enter_outline = IoniconsData(0xead5);
+  static const IconData enter_outline = IoniconsData(0xead5);
 
   /// enter-sharp
-  static const IconData? enter_sharp = IoniconsData(0xead6);
+  static const IconData enter_sharp = IoniconsData(0xead6);
 
   /// exit
-  static const IconData? exit = IoniconsData(0xead7);
+  static const IconData exit = IoniconsData(0xead7);
 
   /// exit-outline
-  static const IconData? exit_outline = IoniconsData(0xead8);
+  static const IconData exit_outline = IoniconsData(0xead8);
 
   /// exit-sharp
-  static const IconData? exit_sharp = IoniconsData(0xead9);
+  static const IconData exit_sharp = IoniconsData(0xead9);
 
   /// expand
-  static const IconData? expand = IoniconsData(0xeada);
+  static const IconData expand = IoniconsData(0xeada);
 
   /// expand-outline
-  static const IconData? expand_outline = IoniconsData(0xeadb);
+  static const IconData expand_outline = IoniconsData(0xeadb);
 
   /// expand-sharp
-  static const IconData? expand_sharp = IoniconsData(0xeadc);
+  static const IconData expand_sharp = IoniconsData(0xeadc);
 
   /// extension-puzzle
-  static const IconData? extension_puzzle = IoniconsData(0xeadd);
+  static const IconData extension_puzzle = IoniconsData(0xeadd);
 
   /// extension-puzzle-outline
-  static const IconData? extension_puzzle_outline = IoniconsData(0xeade);
+  static const IconData extension_puzzle_outline = IoniconsData(0xeade);
 
   /// extension-puzzle-sharp
-  static const IconData? extension_puzzle_sharp = IoniconsData(0xeadf);
+  static const IconData extension_puzzle_sharp = IoniconsData(0xeadf);
 
   /// eye
-  static const IconData? eye = IoniconsData(0xeae0);
+  static const IconData eye = IoniconsData(0xeae0);
 
   /// eyedrop
-  static const IconData? eyedrop = IoniconsData(0xeae1);
+  static const IconData eyedrop = IoniconsData(0xeae1);
 
   /// eyedrop-outline
-  static const IconData? eyedrop_outline = IoniconsData(0xeae2);
+  static const IconData eyedrop_outline = IoniconsData(0xeae2);
 
   /// eyedrop-sharp
-  static const IconData? eyedrop_sharp = IoniconsData(0xeae3);
+  static const IconData eyedrop_sharp = IoniconsData(0xeae3);
 
   /// eye-off
-  static const IconData? eye_off = IoniconsData(0xeae4);
+  static const IconData eye_off = IoniconsData(0xeae4);
 
   /// eye-off-outline
-  static const IconData? eye_off_outline = IoniconsData(0xeae5);
+  static const IconData eye_off_outline = IoniconsData(0xeae5);
 
   /// eye-off-sharp
-  static const IconData? eye_off_sharp = IoniconsData(0xeae6);
+  static const IconData eye_off_sharp = IoniconsData(0xeae6);
 
   /// eye-outline
-  static const IconData? eye_outline = IoniconsData(0xeae7);
+  static const IconData eye_outline = IoniconsData(0xeae7);
 
   /// eye-sharp
-  static const IconData? eye_sharp = IoniconsData(0xeae8);
+  static const IconData eye_sharp = IoniconsData(0xeae8);
 
   /// fast-food
-  static const IconData? fast_food = IoniconsData(0xeae9);
+  static const IconData fast_food = IoniconsData(0xeae9);
 
   /// fast-food-outline
-  static const IconData? fast_food_outline = IoniconsData(0xeaea);
+  static const IconData fast_food_outline = IoniconsData(0xeaea);
 
   /// fast-food-sharp
-  static const IconData? fast_food_sharp = IoniconsData(0xeaeb);
+  static const IconData fast_food_sharp = IoniconsData(0xeaeb);
 
   /// female
-  static const IconData? female = IoniconsData(0xeaec);
+  static const IconData female = IoniconsData(0xeaec);
 
   /// female-outline
-  static const IconData? female_outline = IoniconsData(0xeaed);
+  static const IconData female_outline = IoniconsData(0xeaed);
 
   /// female-sharp
-  static const IconData? female_sharp = IoniconsData(0xeaee);
+  static const IconData female_sharp = IoniconsData(0xeaee);
 
   /// file-tray
-  static const IconData? file_tray = IoniconsData(0xeaef);
+  static const IconData file_tray = IoniconsData(0xeaef);
 
   /// file-tray-full
-  static const IconData? file_tray_full = IoniconsData(0xeaf0);
+  static const IconData file_tray_full = IoniconsData(0xeaf0);
 
   /// file-tray-full-outline
-  static const IconData? file_tray_full_outline = IoniconsData(0xeaf1);
+  static const IconData file_tray_full_outline = IoniconsData(0xeaf1);
 
   /// file-tray-full-sharp
-  static const IconData? file_tray_full_sharp = IoniconsData(0xeaf2);
+  static const IconData file_tray_full_sharp = IoniconsData(0xeaf2);
 
   /// file-tray-outline
-  static const IconData? file_tray_outline = IoniconsData(0xeaf3);
+  static const IconData file_tray_outline = IoniconsData(0xeaf3);
 
   /// file-tray-sharp
-  static const IconData? file_tray_sharp = IoniconsData(0xeaf4);
+  static const IconData file_tray_sharp = IoniconsData(0xeaf4);
 
   /// file-tray-stacked
-  static const IconData? file_tray_stacked = IoniconsData(0xeaf5);
+  static const IconData file_tray_stacked = IoniconsData(0xeaf5);
 
   /// file-tray-stacked-outline
-  static const IconData? file_tray_stacked_outline = IoniconsData(0xeaf6);
+  static const IconData file_tray_stacked_outline = IoniconsData(0xeaf6);
 
   /// file-tray-stacked-sharp
-  static const IconData? file_tray_stacked_sharp = IoniconsData(0xeaf7);
+  static const IconData file_tray_stacked_sharp = IoniconsData(0xeaf7);
 
   /// film
-  static const IconData? film = IoniconsData(0xeaf8);
+  static const IconData film = IoniconsData(0xeaf8);
 
   /// film-outline
-  static const IconData? film_outline = IoniconsData(0xeaf9);
+  static const IconData film_outline = IoniconsData(0xeaf9);
 
   /// film-sharp
-  static const IconData? film_sharp = IoniconsData(0xeafa);
+  static const IconData film_sharp = IoniconsData(0xeafa);
 
   /// filter
-  static const IconData? filter = IoniconsData(0xeafb);
+  static const IconData filter = IoniconsData(0xeafb);
 
   /// filter-circle
-  static const IconData? filter_circle = IoniconsData(0xeafc);
+  static const IconData filter_circle = IoniconsData(0xeafc);
 
   /// filter-circle-outline
-  static const IconData? filter_circle_outline = IoniconsData(0xeafd);
+  static const IconData filter_circle_outline = IoniconsData(0xeafd);
 
   /// filter-circle-sharp
-  static const IconData? filter_circle_sharp = IoniconsData(0xeafe);
+  static const IconData filter_circle_sharp = IoniconsData(0xeafe);
 
   /// filter-outline
-  static const IconData? filter_outline = IoniconsData(0xeaff);
+  static const IconData filter_outline = IoniconsData(0xeaff);
 
   /// filter-sharp
-  static const IconData? filter_sharp = IoniconsData(0xeb00);
+  static const IconData filter_sharp = IoniconsData(0xeb00);
 
   /// finger-print
-  static const IconData? finger_print = IoniconsData(0xeb01);
+  static const IconData finger_print = IoniconsData(0xeb01);
 
   /// finger-print-outline
-  static const IconData? finger_print_outline = IoniconsData(0xeb02);
+  static const IconData finger_print_outline = IoniconsData(0xeb02);
 
   /// finger-print-sharp
-  static const IconData? finger_print_sharp = IoniconsData(0xeb03);
+  static const IconData finger_print_sharp = IoniconsData(0xeb03);
 
   /// fish
-  static const IconData? fish = IoniconsData(0xeb04);
+  static const IconData fish = IoniconsData(0xeb04);
 
   /// fish-outline
-  static const IconData? fish_outline = IoniconsData(0xeb05);
+  static const IconData fish_outline = IoniconsData(0xeb05);
 
   /// fish-sharp
-  static const IconData? fish_sharp = IoniconsData(0xeb06);
+  static const IconData fish_sharp = IoniconsData(0xeb06);
 
   /// fitness
-  static const IconData? fitness = IoniconsData(0xeb07);
+  static const IconData fitness = IoniconsData(0xeb07);
 
   /// fitness-outline
-  static const IconData? fitness_outline = IoniconsData(0xeb08);
+  static const IconData fitness_outline = IoniconsData(0xeb08);
 
   /// fitness-sharp
-  static const IconData? fitness_sharp = IoniconsData(0xeb09);
+  static const IconData fitness_sharp = IoniconsData(0xeb09);
 
   /// flag
-  static const IconData? flag = IoniconsData(0xeb0a);
+  static const IconData flag = IoniconsData(0xeb0a);
 
   /// flag-outline
-  static const IconData? flag_outline = IoniconsData(0xeb0b);
+  static const IconData flag_outline = IoniconsData(0xeb0b);
 
   /// flag-sharp
-  static const IconData? flag_sharp = IoniconsData(0xeb0c);
+  static const IconData flag_sharp = IoniconsData(0xeb0c);
 
   /// flame
-  static const IconData? flame = IoniconsData(0xeb0d);
+  static const IconData flame = IoniconsData(0xeb0d);
 
   /// flame-outline
-  static const IconData? flame_outline = IoniconsData(0xeb0e);
+  static const IconData flame_outline = IoniconsData(0xeb0e);
 
   /// flame-sharp
-  static const IconData? flame_sharp = IoniconsData(0xeb0f);
+  static const IconData flame_sharp = IoniconsData(0xeb0f);
 
   /// flash
-  static const IconData? flash = IoniconsData(0xeb10);
+  static const IconData flash = IoniconsData(0xeb10);
 
   /// flashlight
-  static const IconData? flashlight = IoniconsData(0xeb11);
+  static const IconData flashlight = IoniconsData(0xeb11);
 
   /// flashlight-outline
-  static const IconData? flashlight_outline = IoniconsData(0xeb12);
+  static const IconData flashlight_outline = IoniconsData(0xeb12);
 
   /// flashlight-sharp
-  static const IconData? flashlight_sharp = IoniconsData(0xeb13);
+  static const IconData flashlight_sharp = IoniconsData(0xeb13);
 
   /// flash-off
-  static const IconData? flash_off = IoniconsData(0xeb14);
+  static const IconData flash_off = IoniconsData(0xeb14);
 
   /// flash-off-outline
-  static const IconData? flash_off_outline = IoniconsData(0xeb15);
+  static const IconData flash_off_outline = IoniconsData(0xeb15);
 
   /// flash-off-sharp
-  static const IconData? flash_off_sharp = IoniconsData(0xeb16);
+  static const IconData flash_off_sharp = IoniconsData(0xeb16);
 
   /// flash-outline
-  static const IconData? flash_outline = IoniconsData(0xeb17);
+  static const IconData flash_outline = IoniconsData(0xeb17);
 
   /// flash-sharp
-  static const IconData? flash_sharp = IoniconsData(0xeb18);
+  static const IconData flash_sharp = IoniconsData(0xeb18);
 
   /// flask
-  static const IconData? flask = IoniconsData(0xeb19);
+  static const IconData flask = IoniconsData(0xeb19);
 
   /// flask-outline
-  static const IconData? flask_outline = IoniconsData(0xeb1a);
+  static const IconData flask_outline = IoniconsData(0xeb1a);
 
   /// flask-sharp
-  static const IconData? flask_sharp = IoniconsData(0xeb1b);
+  static const IconData flask_sharp = IoniconsData(0xeb1b);
 
   /// flower
-  static const IconData? flower = IoniconsData(0xeb1c);
+  static const IconData flower = IoniconsData(0xeb1c);
 
   /// flower-outline
-  static const IconData? flower_outline = IoniconsData(0xeb1d);
+  static const IconData flower_outline = IoniconsData(0xeb1d);
 
   /// flower-sharp
-  static const IconData? flower_sharp = IoniconsData(0xeb1e);
+  static const IconData flower_sharp = IoniconsData(0xeb1e);
 
   /// folder
-  static const IconData? folder = IoniconsData(0xeb1f);
+  static const IconData folder = IoniconsData(0xeb1f);
 
   /// folder-open
-  static const IconData? folder_open = IoniconsData(0xeb20);
+  static const IconData folder_open = IoniconsData(0xeb20);
 
   /// folder-open-outline
-  static const IconData? folder_open_outline = IoniconsData(0xeb21);
+  static const IconData folder_open_outline = IoniconsData(0xeb21);
 
   /// folder-open-sharp
-  static const IconData? folder_open_sharp = IoniconsData(0xeb22);
+  static const IconData folder_open_sharp = IoniconsData(0xeb22);
 
   /// folder-outline
-  static const IconData? folder_outline = IoniconsData(0xeb23);
+  static const IconData folder_outline = IoniconsData(0xeb23);
 
   /// folder-sharp
-  static const IconData? folder_sharp = IoniconsData(0xeb24);
+  static const IconData folder_sharp = IoniconsData(0xeb24);
 
   /// football
-  static const IconData? football = IoniconsData(0xeb25);
+  static const IconData football = IoniconsData(0xeb25);
 
   /// football-outline
-  static const IconData? football_outline = IoniconsData(0xeb26);
+  static const IconData football_outline = IoniconsData(0xeb26);
 
   /// football-sharp
-  static const IconData? football_sharp = IoniconsData(0xeb27);
+  static const IconData football_sharp = IoniconsData(0xeb27);
 
   /// footsteps
-  static const IconData? footsteps = IoniconsData(0xeb28);
+  static const IconData footsteps = IoniconsData(0xeb28);
 
   /// footsteps-outline
-  static const IconData? footsteps_outline = IoniconsData(0xeb29);
+  static const IconData footsteps_outline = IoniconsData(0xeb29);
 
   /// footsteps-sharp
-  static const IconData? footsteps_sharp = IoniconsData(0xeb2a);
+  static const IconData footsteps_sharp = IoniconsData(0xeb2a);
 
   /// funnel
-  static const IconData? funnel = IoniconsData(0xeb2b);
+  static const IconData funnel = IoniconsData(0xeb2b);
 
   /// funnel-outline
-  static const IconData? funnel_outline = IoniconsData(0xeb2c);
+  static const IconData funnel_outline = IoniconsData(0xeb2c);
 
   /// funnel-sharp
-  static const IconData? funnel_sharp = IoniconsData(0xeb2d);
+  static const IconData funnel_sharp = IoniconsData(0xeb2d);
 
   /// game-controller
-  static const IconData? game_controller = IoniconsData(0xeb2e);
+  static const IconData game_controller = IoniconsData(0xeb2e);
 
   /// game-controller-outline
-  static const IconData? game_controller_outline = IoniconsData(0xeb2f);
+  static const IconData game_controller_outline = IoniconsData(0xeb2f);
 
   /// game-controller-sharp
-  static const IconData? game_controller_sharp = IoniconsData(0xeb30);
+  static const IconData game_controller_sharp = IoniconsData(0xeb30);
 
   /// gift
-  static const IconData? gift = IoniconsData(0xeb31);
+  static const IconData gift = IoniconsData(0xeb31);
 
   /// gift-outline
-  static const IconData? gift_outline = IoniconsData(0xeb32);
+  static const IconData gift_outline = IoniconsData(0xeb32);
 
   /// gift-sharp
-  static const IconData? gift_sharp = IoniconsData(0xeb33);
+  static const IconData gift_sharp = IoniconsData(0xeb33);
 
   /// git-branch
-  static const IconData? git_branch = IoniconsData(0xeb34);
+  static const IconData git_branch = IoniconsData(0xeb34);
 
   /// git-branch-outline
-  static const IconData? git_branch_outline = IoniconsData(0xeb35);
+  static const IconData git_branch_outline = IoniconsData(0xeb35);
 
   /// git-branch-sharp
-  static const IconData? git_branch_sharp = IoniconsData(0xeb36);
+  static const IconData git_branch_sharp = IoniconsData(0xeb36);
 
   /// git-commit
-  static const IconData? git_commit = IoniconsData(0xeb37);
+  static const IconData git_commit = IoniconsData(0xeb37);
 
   /// git-commit-outline
-  static const IconData? git_commit_outline = IoniconsData(0xeb38);
+  static const IconData git_commit_outline = IoniconsData(0xeb38);
 
   /// git-commit-sharp
-  static const IconData? git_commit_sharp = IoniconsData(0xeb39);
+  static const IconData git_commit_sharp = IoniconsData(0xeb39);
 
   /// git-compare
-  static const IconData? git_compare = IoniconsData(0xeb3a);
+  static const IconData git_compare = IoniconsData(0xeb3a);
 
   /// git-compare-outline
-  static const IconData? git_compare_outline = IoniconsData(0xeb3b);
+  static const IconData git_compare_outline = IoniconsData(0xeb3b);
 
   /// git-compare-sharp
-  static const IconData? git_compare_sharp = IoniconsData(0xeb3c);
+  static const IconData git_compare_sharp = IoniconsData(0xeb3c);
 
   /// git-merge
-  static const IconData? git_merge = IoniconsData(0xeb3d);
+  static const IconData git_merge = IoniconsData(0xeb3d);
 
   /// git-merge-outline
-  static const IconData? git_merge_outline = IoniconsData(0xeb3e);
+  static const IconData git_merge_outline = IoniconsData(0xeb3e);
 
   /// git-merge-sharp
-  static const IconData? git_merge_sharp = IoniconsData(0xeb3f);
+  static const IconData git_merge_sharp = IoniconsData(0xeb3f);
 
   /// git-network
-  static const IconData? git_network = IoniconsData(0xeb40);
+  static const IconData git_network = IoniconsData(0xeb40);
 
   /// git-network-outline
-  static const IconData? git_network_outline = IoniconsData(0xeb41);
+  static const IconData git_network_outline = IoniconsData(0xeb41);
 
   /// git-network-sharp
-  static const IconData? git_network_sharp = IoniconsData(0xeb42);
+  static const IconData git_network_sharp = IoniconsData(0xeb42);
 
   /// git-pull-request
-  static const IconData? git_pull_request = IoniconsData(0xeb43);
+  static const IconData git_pull_request = IoniconsData(0xeb43);
 
   /// git-pull-request-outline
-  static const IconData? git_pull_request_outline = IoniconsData(0xeb44);
+  static const IconData git_pull_request_outline = IoniconsData(0xeb44);
 
   /// git-pull-request-sharp
-  static const IconData? git_pull_request_sharp = IoniconsData(0xeb45);
+  static const IconData git_pull_request_sharp = IoniconsData(0xeb45);
 
   /// glasses
-  static const IconData? glasses = IoniconsData(0xeb46);
+  static const IconData glasses = IoniconsData(0xeb46);
 
   /// glasses-outline
-  static const IconData? glasses_outline = IoniconsData(0xeb47);
+  static const IconData glasses_outline = IoniconsData(0xeb47);
 
   /// glasses-sharp
-  static const IconData? glasses_sharp = IoniconsData(0xeb48);
+  static const IconData glasses_sharp = IoniconsData(0xeb48);
 
   /// globe
-  static const IconData? globe = IoniconsData(0xeb49);
+  static const IconData globe = IoniconsData(0xeb49);
 
   /// globe-outline
-  static const IconData? globe_outline = IoniconsData(0xeb4a);
+  static const IconData globe_outline = IoniconsData(0xeb4a);
 
   /// globe-sharp
-  static const IconData? globe_sharp = IoniconsData(0xeb4b);
+  static const IconData globe_sharp = IoniconsData(0xeb4b);
 
   /// golf
-  static const IconData? golf = IoniconsData(0xeb4c);
+  static const IconData golf = IoniconsData(0xeb4c);
 
   /// golf-outline
-  static const IconData? golf_outline = IoniconsData(0xeb4d);
+  static const IconData golf_outline = IoniconsData(0xeb4d);
 
   /// golf-sharp
-  static const IconData? golf_sharp = IoniconsData(0xeb4e);
+  static const IconData golf_sharp = IoniconsData(0xeb4e);
 
   /// grid
-  static const IconData? grid = IoniconsData(0xeb4f);
+  static const IconData grid = IoniconsData(0xeb4f);
 
   /// grid-outline
-  static const IconData? grid_outline = IoniconsData(0xeb50);
+  static const IconData grid_outline = IoniconsData(0xeb50);
 
   /// grid-sharp
-  static const IconData? grid_sharp = IoniconsData(0xeb51);
+  static const IconData grid_sharp = IoniconsData(0xeb51);
 
   /// hammer
-  static const IconData? hammer = IoniconsData(0xeb52);
+  static const IconData hammer = IoniconsData(0xeb52);
 
   /// hammer-outline
-  static const IconData? hammer_outline = IoniconsData(0xeb53);
+  static const IconData hammer_outline = IoniconsData(0xeb53);
 
   /// hammer-sharp
-  static const IconData? hammer_sharp = IoniconsData(0xeb54);
+  static const IconData hammer_sharp = IoniconsData(0xeb54);
 
   /// hand-left
-  static const IconData? hand_left = IoniconsData(0xeb55);
+  static const IconData hand_left = IoniconsData(0xeb55);
 
   /// hand-left-outline
-  static const IconData? hand_left_outline = IoniconsData(0xeb56);
+  static const IconData hand_left_outline = IoniconsData(0xeb56);
 
   /// hand-left-sharp
-  static const IconData? hand_left_sharp = IoniconsData(0xeb57);
+  static const IconData hand_left_sharp = IoniconsData(0xeb57);
 
   /// hand-right
-  static const IconData? hand_right = IoniconsData(0xeb58);
+  static const IconData hand_right = IoniconsData(0xeb58);
 
   /// hand-right-outline
-  static const IconData? hand_right_outline = IoniconsData(0xeb59);
+  static const IconData hand_right_outline = IoniconsData(0xeb59);
 
   /// hand-right-sharp
-  static const IconData? hand_right_sharp = IoniconsData(0xeb5a);
+  static const IconData hand_right_sharp = IoniconsData(0xeb5a);
 
   /// happy
-  static const IconData? happy = IoniconsData(0xeb5b);
+  static const IconData happy = IoniconsData(0xeb5b);
 
   /// happy-outline
-  static const IconData? happy_outline = IoniconsData(0xeb5c);
+  static const IconData happy_outline = IoniconsData(0xeb5c);
 
   /// happy-sharp
-  static const IconData? happy_sharp = IoniconsData(0xeb5d);
+  static const IconData happy_sharp = IoniconsData(0xeb5d);
 
   /// hardware-chip
-  static const IconData? hardware_chip = IoniconsData(0xeb5e);
+  static const IconData hardware_chip = IoniconsData(0xeb5e);
 
   /// hardware-chip-outline
-  static const IconData? hardware_chip_outline = IoniconsData(0xeb5f);
+  static const IconData hardware_chip_outline = IoniconsData(0xeb5f);
 
   /// hardware-chip-sharp
-  static const IconData? hardware_chip_sharp = IoniconsData(0xeb60);
+  static const IconData hardware_chip_sharp = IoniconsData(0xeb60);
 
   /// headset
-  static const IconData? headset = IoniconsData(0xeb61);
+  static const IconData headset = IoniconsData(0xeb61);
 
   /// headset-outline
-  static const IconData? headset_outline = IoniconsData(0xeb62);
+  static const IconData headset_outline = IoniconsData(0xeb62);
 
   /// headset-sharp
-  static const IconData? headset_sharp = IoniconsData(0xeb63);
+  static const IconData headset_sharp = IoniconsData(0xeb63);
 
   /// heart
-  static const IconData? heart = IoniconsData(0xeb64);
+  static const IconData heart = IoniconsData(0xeb64);
 
   /// heart-circle
-  static const IconData? heart_circle = IoniconsData(0xeb65);
+  static const IconData heart_circle = IoniconsData(0xeb65);
 
   /// heart-circle-outline
-  static const IconData? heart_circle_outline = IoniconsData(0xeb66);
+  static const IconData heart_circle_outline = IoniconsData(0xeb66);
 
   /// heart-circle-sharp
-  static const IconData? heart_circle_sharp = IoniconsData(0xeb67);
+  static const IconData heart_circle_sharp = IoniconsData(0xeb67);
 
   /// heart-dislike
-  static const IconData? heart_dislike = IoniconsData(0xeb68);
+  static const IconData heart_dislike = IoniconsData(0xeb68);
 
   /// heart-dislike-circle
-  static const IconData? heart_dislike_circle = IoniconsData(0xeb69);
+  static const IconData heart_dislike_circle = IoniconsData(0xeb69);
 
   /// heart-dislike-circle-outline
-  static const IconData? heart_dislike_circle_outline = IoniconsData(0xeb6a);
+  static const IconData heart_dislike_circle_outline = IoniconsData(0xeb6a);
 
   /// heart-dislike-circle-sharp
-  static const IconData? heart_dislike_circle_sharp = IoniconsData(0xeb6b);
+  static const IconData heart_dislike_circle_sharp = IoniconsData(0xeb6b);
 
   /// heart-dislike-outline
-  static const IconData? heart_dislike_outline = IoniconsData(0xeb6c);
+  static const IconData heart_dislike_outline = IoniconsData(0xeb6c);
 
   /// heart-dislike-sharp
-  static const IconData? heart_dislike_sharp = IoniconsData(0xeb6d);
+  static const IconData heart_dislike_sharp = IoniconsData(0xeb6d);
 
   /// heart-half
-  static const IconData? heart_half = IoniconsData(0xeb6e);
+  static const IconData heart_half = IoniconsData(0xeb6e);
 
   /// heart-half-outline
-  static const IconData? heart_half_outline = IoniconsData(0xeb6f);
+  static const IconData heart_half_outline = IoniconsData(0xeb6f);
 
   /// heart-half-sharp
-  static const IconData? heart_half_sharp = IoniconsData(0xeb70);
+  static const IconData heart_half_sharp = IoniconsData(0xeb70);
 
   /// heart-outline
-  static const IconData? heart_outline = IoniconsData(0xeb71);
+  static const IconData heart_outline = IoniconsData(0xeb71);
 
   /// heart-sharp
-  static const IconData? heart_sharp = IoniconsData(0xeb72);
+  static const IconData heart_sharp = IoniconsData(0xeb72);
 
   /// help
-  static const IconData? help = IoniconsData(0xeb73);
+  static const IconData help = IoniconsData(0xeb73);
 
   /// help-buoy
-  static const IconData? help_buoy = IoniconsData(0xeb74);
+  static const IconData help_buoy = IoniconsData(0xeb74);
 
   /// help-buoy-outline
-  static const IconData? help_buoy_outline = IoniconsData(0xeb75);
+  static const IconData help_buoy_outline = IoniconsData(0xeb75);
 
   /// help-buoy-sharp
-  static const IconData? help_buoy_sharp = IoniconsData(0xeb76);
+  static const IconData help_buoy_sharp = IoniconsData(0xeb76);
 
   /// help-circle
-  static const IconData? help_circle = IoniconsData(0xeb77);
+  static const IconData help_circle = IoniconsData(0xeb77);
 
   /// help-circle-outline
-  static const IconData? help_circle_outline = IoniconsData(0xeb78);
+  static const IconData help_circle_outline = IoniconsData(0xeb78);
 
   /// help-circle-sharp
-  static const IconData? help_circle_sharp = IoniconsData(0xeb79);
+  static const IconData help_circle_sharp = IoniconsData(0xeb79);
 
   /// help-outline
-  static const IconData? help_outline = IoniconsData(0xeb7a);
+  static const IconData help_outline = IoniconsData(0xeb7a);
 
   /// help-sharp
-  static const IconData? help_sharp = IoniconsData(0xeb7b);
+  static const IconData help_sharp = IoniconsData(0xeb7b);
 
   /// home
-  static const IconData? home = IoniconsData(0xeb7c);
+  static const IconData home = IoniconsData(0xeb7c);
 
   /// home-outline
-  static const IconData? home_outline = IoniconsData(0xeb7d);
+  static const IconData home_outline = IoniconsData(0xeb7d);
 
   /// home-sharp
-  static const IconData? home_sharp = IoniconsData(0xeb7e);
+  static const IconData home_sharp = IoniconsData(0xeb7e);
 
   /// hourglass
-  static const IconData? hourglass = IoniconsData(0xeb7f);
+  static const IconData hourglass = IoniconsData(0xeb7f);
 
   /// hourglass-outline
-  static const IconData? hourglass_outline = IoniconsData(0xeb80);
+  static const IconData hourglass_outline = IoniconsData(0xeb80);
 
   /// hourglass-sharp
-  static const IconData? hourglass_sharp = IoniconsData(0xeb81);
+  static const IconData hourglass_sharp = IoniconsData(0xeb81);
 
   /// ice-cream
-  static const IconData? ice_cream = IoniconsData(0xeb82);
+  static const IconData ice_cream = IoniconsData(0xeb82);
 
   /// ice-cream-outline
-  static const IconData? ice_cream_outline = IoniconsData(0xeb83);
+  static const IconData ice_cream_outline = IoniconsData(0xeb83);
 
   /// ice-cream-sharp
-  static const IconData? ice_cream_sharp = IoniconsData(0xeb84);
+  static const IconData ice_cream_sharp = IoniconsData(0xeb84);
 
   /// id-card
-  static const IconData? id_card = IoniconsData(0xeb85);
+  static const IconData id_card = IoniconsData(0xeb85);
 
   /// id-card-outline
-  static const IconData? id_card_outline = IoniconsData(0xeb86);
+  static const IconData id_card_outline = IoniconsData(0xeb86);
 
   /// id-card-sharp
-  static const IconData? id_card_sharp = IoniconsData(0xeb87);
+  static const IconData id_card_sharp = IoniconsData(0xeb87);
 
   /// image
-  static const IconData? image = IoniconsData(0xeb88);
+  static const IconData image = IoniconsData(0xeb88);
 
   /// image-outline
-  static const IconData? image_outline = IoniconsData(0xeb89);
+  static const IconData image_outline = IoniconsData(0xeb89);
 
   /// images
-  static const IconData? images = IoniconsData(0xeb8a);
+  static const IconData images = IoniconsData(0xeb8a);
 
   /// image-sharp
-  static const IconData? image_sharp = IoniconsData(0xeb8b);
+  static const IconData image_sharp = IoniconsData(0xeb8b);
 
   /// images-outline
-  static const IconData? images_outline = IoniconsData(0xeb8c);
+  static const IconData images_outline = IoniconsData(0xeb8c);
 
   /// images-sharp
-  static const IconData? images_sharp = IoniconsData(0xeb8d);
+  static const IconData images_sharp = IoniconsData(0xeb8d);
 
   /// infinite
-  static const IconData? infinite = IoniconsData(0xeb8e);
+  static const IconData infinite = IoniconsData(0xeb8e);
 
   /// infinite-outline
-  static const IconData? infinite_outline = IoniconsData(0xeb8f);
+  static const IconData infinite_outline = IoniconsData(0xeb8f);
 
   /// infinite-sharp
-  static const IconData? infinite_sharp = IoniconsData(0xeb90);
+  static const IconData infinite_sharp = IoniconsData(0xeb90);
 
   /// information
-  static const IconData? information = IoniconsData(0xeb91);
+  static const IconData information = IoniconsData(0xeb91);
 
   /// information-circle
-  static const IconData? information_circle = IoniconsData(0xeb92);
+  static const IconData information_circle = IoniconsData(0xeb92);
 
   /// information-circle-outline
-  static const IconData? information_circle_outline = IoniconsData(0xeb93);
+  static const IconData information_circle_outline = IoniconsData(0xeb93);
 
   /// information-circle-sharp
-  static const IconData? information_circle_sharp = IoniconsData(0xeb94);
+  static const IconData information_circle_sharp = IoniconsData(0xeb94);
 
   /// information-outline
-  static const IconData? information_outline = IoniconsData(0xeb95);
+  static const IconData information_outline = IoniconsData(0xeb95);
 
   /// information-sharp
-  static const IconData? information_sharp = IoniconsData(0xeb96);
+  static const IconData information_sharp = IoniconsData(0xeb96);
 
   /// invert-mode
-  static const IconData? invert_mode = IoniconsData(0xeb97);
+  static const IconData invert_mode = IoniconsData(0xeb97);
 
   /// invert-mode-outline
-  static const IconData? invert_mode_outline = IoniconsData(0xeb98);
+  static const IconData invert_mode_outline = IoniconsData(0xeb98);
 
   /// invert-mode-sharp
-  static const IconData? invert_mode_sharp = IoniconsData(0xeb99);
+  static const IconData invert_mode_sharp = IoniconsData(0xeb99);
 
   /// journal
-  static const IconData? journal = IoniconsData(0xeb9a);
+  static const IconData journal = IoniconsData(0xeb9a);
 
   /// journal-outline
-  static const IconData? journal_outline = IoniconsData(0xeb9b);
+  static const IconData journal_outline = IoniconsData(0xeb9b);
 
   /// journal-sharp
-  static const IconData? journal_sharp = IoniconsData(0xeb9c);
+  static const IconData journal_sharp = IoniconsData(0xeb9c);
 
   /// key
-  static const IconData? key = IoniconsData(0xeb9d);
+  static const IconData key = IoniconsData(0xeb9d);
 
   /// key-outline
-  static const IconData? key_outline = IoniconsData(0xeb9e);
+  static const IconData key_outline = IoniconsData(0xeb9e);
 
   /// keypad
-  static const IconData? keypad = IoniconsData(0xeb9f);
+  static const IconData keypad = IoniconsData(0xeb9f);
 
   /// keypad-outline
-  static const IconData? keypad_outline = IoniconsData(0xeba0);
+  static const IconData keypad_outline = IoniconsData(0xeba0);
 
   /// keypad-sharp
-  static const IconData? keypad_sharp = IoniconsData(0xeba1);
+  static const IconData keypad_sharp = IoniconsData(0xeba1);
 
   /// key-sharp
-  static const IconData? key_sharp = IoniconsData(0xeba2);
+  static const IconData key_sharp = IoniconsData(0xeba2);
 
   /// language
-  static const IconData? language = IoniconsData(0xeba3);
+  static const IconData language = IoniconsData(0xeba3);
 
   /// language-outline
-  static const IconData? language_outline = IoniconsData(0xeba4);
+  static const IconData language_outline = IoniconsData(0xeba4);
 
   /// language-sharp
-  static const IconData? language_sharp = IoniconsData(0xeba5);
+  static const IconData language_sharp = IoniconsData(0xeba5);
 
   /// laptop
-  static const IconData? laptop = IoniconsData(0xeba6);
+  static const IconData laptop = IoniconsData(0xeba6);
 
   /// laptop-outline
-  static const IconData? laptop_outline = IoniconsData(0xeba7);
+  static const IconData laptop_outline = IoniconsData(0xeba7);
 
   /// laptop-sharp
-  static const IconData? laptop_sharp = IoniconsData(0xeba8);
+  static const IconData laptop_sharp = IoniconsData(0xeba8);
 
   /// layers
-  static const IconData? layers = IoniconsData(0xeba9);
+  static const IconData layers = IoniconsData(0xeba9);
 
   /// layers-outline
-  static const IconData? layers_outline = IoniconsData(0xebaa);
+  static const IconData layers_outline = IoniconsData(0xebaa);
 
   /// layers-sharp
-  static const IconData? layers_sharp = IoniconsData(0xebab);
+  static const IconData layers_sharp = IoniconsData(0xebab);
 
   /// leaf
-  static const IconData? leaf = IoniconsData(0xebac);
+  static const IconData leaf = IoniconsData(0xebac);
 
   /// leaf-outline
-  static const IconData? leaf_outline = IoniconsData(0xebad);
+  static const IconData leaf_outline = IoniconsData(0xebad);
 
   /// leaf-sharp
-  static const IconData? leaf_sharp = IoniconsData(0xebae);
+  static const IconData leaf_sharp = IoniconsData(0xebae);
 
   /// library
-  static const IconData? library = IoniconsData(0xebaf);
+  static const IconData library = IoniconsData(0xebaf);
 
   /// library-outline
-  static const IconData? library_outline = IoniconsData(0xebb0);
+  static const IconData library_outline = IoniconsData(0xebb0);
 
   /// library-sharp
-  static const IconData? library_sharp = IoniconsData(0xebb1);
+  static const IconData library_sharp = IoniconsData(0xebb1);
 
   /// link
-  static const IconData? link = IoniconsData(0xebb2);
+  static const IconData link = IoniconsData(0xebb2);
 
   /// link-outline
-  static const IconData? link_outline = IoniconsData(0xebb3);
+  static const IconData link_outline = IoniconsData(0xebb3);
 
   /// link-sharp
-  static const IconData? link_sharp = IoniconsData(0xebb4);
+  static const IconData link_sharp = IoniconsData(0xebb4);
 
   /// list
-  static const IconData? list = IoniconsData(0xebb5);
+  static const IconData list = IoniconsData(0xebb5);
 
   /// list-circle
-  static const IconData? list_circle = IoniconsData(0xebb6);
+  static const IconData list_circle = IoniconsData(0xebb6);
 
   /// list-circle-outline
-  static const IconData? list_circle_outline = IoniconsData(0xebb7);
+  static const IconData list_circle_outline = IoniconsData(0xebb7);
 
   /// list-circle-sharp
-  static const IconData? list_circle_sharp = IoniconsData(0xebb8);
+  static const IconData list_circle_sharp = IoniconsData(0xebb8);
 
   /// list-outline
-  static const IconData? list_outline = IoniconsData(0xebb9);
+  static const IconData list_outline = IoniconsData(0xebb9);
 
   /// list-sharp
-  static const IconData? list_sharp = IoniconsData(0xebba);
+  static const IconData list_sharp = IoniconsData(0xebba);
 
   /// locate
-  static const IconData? locate = IoniconsData(0xebbb);
+  static const IconData locate = IoniconsData(0xebbb);
 
   /// locate-outline
-  static const IconData? locate_outline = IoniconsData(0xebbc);
+  static const IconData locate_outline = IoniconsData(0xebbc);
 
   /// locate-sharp
-  static const IconData? locate_sharp = IoniconsData(0xebbd);
+  static const IconData locate_sharp = IoniconsData(0xebbd);
 
   /// location
-  static const IconData? location = IoniconsData(0xebbe);
+  static const IconData location = IoniconsData(0xebbe);
 
   /// location-outline
-  static const IconData? location_outline = IoniconsData(0xebbf);
+  static const IconData location_outline = IoniconsData(0xebbf);
 
   /// location-sharp
-  static const IconData? location_sharp = IoniconsData(0xebc0);
+  static const IconData location_sharp = IoniconsData(0xebc0);
 
   /// lock-closed
-  static const IconData? lock_closed = IoniconsData(0xebc1);
+  static const IconData lock_closed = IoniconsData(0xebc1);
 
   /// lock-closed-outline
-  static const IconData? lock_closed_outline = IoniconsData(0xebc2);
+  static const IconData lock_closed_outline = IoniconsData(0xebc2);
 
   /// lock-closed-sharp
-  static const IconData? lock_closed_sharp = IoniconsData(0xebc3);
+  static const IconData lock_closed_sharp = IoniconsData(0xebc3);
 
   /// lock-open
-  static const IconData? lock_open = IoniconsData(0xebc4);
+  static const IconData lock_open = IoniconsData(0xebc4);
 
   /// lock-open-outline
-  static const IconData? lock_open_outline = IoniconsData(0xebc5);
+  static const IconData lock_open_outline = IoniconsData(0xebc5);
 
   /// lock-open-sharp
-  static const IconData? lock_open_sharp = IoniconsData(0xebc6);
+  static const IconData lock_open_sharp = IoniconsData(0xebc6);
 
   /// log-in
-  static const IconData? log_in = IoniconsData(0xebc7);
+  static const IconData log_in = IoniconsData(0xebc7);
 
   /// log-in-outline
-  static const IconData? log_in_outline = IoniconsData(0xebc8);
+  static const IconData log_in_outline = IoniconsData(0xebc8);
 
   /// log-in-sharp
-  static const IconData? log_in_sharp = IoniconsData(0xebc9);
+  static const IconData log_in_sharp = IoniconsData(0xebc9);
 
   /// logo-alipay
-  static const IconData? logo_alipay = IoniconsData(0xebca);
+  static const IconData logo_alipay = IoniconsData(0xebca);
 
   /// logo-amazon
-  static const IconData? logo_amazon = IoniconsData(0xebcb);
+  static const IconData logo_amazon = IoniconsData(0xebcb);
 
   /// logo-amplify
-  static const IconData? logo_amplify = IoniconsData(0xebcc);
+  static const IconData logo_amplify = IoniconsData(0xebcc);
 
   /// logo-android
-  static const IconData? logo_android = IoniconsData(0xebcd);
+  static const IconData logo_android = IoniconsData(0xebcd);
 
   /// logo-angular
-  static const IconData? logo_angular = IoniconsData(0xebce);
+  static const IconData logo_angular = IoniconsData(0xebce);
 
   /// logo-apple
-  static const IconData? logo_apple = IoniconsData(0xebcf);
+  static const IconData logo_apple = IoniconsData(0xebcf);
 
   /// logo-apple-appstore
-  static const IconData? logo_apple_appstore = IoniconsData(0xebd0);
+  static const IconData logo_apple_appstore = IoniconsData(0xebd0);
 
   /// logo-apple-ar
-  static const IconData? logo_apple_ar = IoniconsData(0xebd1);
+  static const IconData logo_apple_ar = IoniconsData(0xebd1);
 
   /// logo-behance
-  static const IconData? logo_behance = IoniconsData(0xebd2);
+  static const IconData logo_behance = IoniconsData(0xebd2);
 
   /// logo-bitbucket
-  static const IconData? logo_bitbucket = IoniconsData(0xebd3);
+  static const IconData logo_bitbucket = IoniconsData(0xebd3);
 
   /// logo-bitcoin
-  static const IconData? logo_bitcoin = IoniconsData(0xebd4);
+  static const IconData logo_bitcoin = IoniconsData(0xebd4);
 
   /// logo-buffer
-  static const IconData? logo_buffer = IoniconsData(0xebd5);
+  static const IconData logo_buffer = IoniconsData(0xebd5);
 
   /// logo-capacitor
-  static const IconData? logo_capacitor = IoniconsData(0xebd6);
+  static const IconData logo_capacitor = IoniconsData(0xebd6);
 
   /// logo-chrome
-  static const IconData? logo_chrome = IoniconsData(0xebd7);
+  static const IconData logo_chrome = IoniconsData(0xebd7);
 
   /// logo-closed-captioning
-  static const IconData? logo_closed_captioning = IoniconsData(0xebd8);
+  static const IconData logo_closed_captioning = IoniconsData(0xebd8);
 
   /// logo-codepen
-  static const IconData? logo_codepen = IoniconsData(0xebd9);
+  static const IconData logo_codepen = IoniconsData(0xebd9);
 
   /// logo-css3
-  static const IconData? logo_css3 = IoniconsData(0xebda);
+  static const IconData logo_css3 = IoniconsData(0xebda);
 
   /// logo-designernews
-  static const IconData? logo_designernews = IoniconsData(0xebdb);
+  static const IconData logo_designernews = IoniconsData(0xebdb);
 
   /// logo-deviantart
-  static const IconData? logo_deviantart = IoniconsData(0xebdc);
+  static const IconData logo_deviantart = IoniconsData(0xebdc);
 
   /// logo-discord
-  static const IconData? logo_discord = IoniconsData(0xebdd);
+  static const IconData logo_discord = IoniconsData(0xebdd);
 
   /// logo-docker
-  static const IconData? logo_docker = IoniconsData(0xebde);
+  static const IconData logo_docker = IoniconsData(0xebde);
 
   /// logo-dribbble
-  static const IconData? logo_dribbble = IoniconsData(0xebdf);
+  static const IconData logo_dribbble = IoniconsData(0xebdf);
 
   /// logo-dropbox
-  static const IconData? logo_dropbox = IoniconsData(0xebe0);
+  static const IconData logo_dropbox = IoniconsData(0xebe0);
 
   /// logo-edge
-  static const IconData? logo_edge = IoniconsData(0xebe1);
+  static const IconData logo_edge = IoniconsData(0xebe1);
 
   /// logo-electron
-  static const IconData? logo_electron = IoniconsData(0xebe2);
+  static const IconData logo_electron = IoniconsData(0xebe2);
 
   /// logo-euro
-  static const IconData? logo_euro = IoniconsData(0xebe3);
+  static const IconData logo_euro = IoniconsData(0xebe3);
 
   /// logo-facebook
-  static const IconData? logo_facebook = IoniconsData(0xebe4);
+  static const IconData logo_facebook = IoniconsData(0xebe4);
 
   /// logo-figma
-  static const IconData? logo_figma = IoniconsData(0xebe5);
+  static const IconData logo_figma = IoniconsData(0xebe5);
 
   /// logo-firebase
-  static const IconData? logo_firebase = IoniconsData(0xebe6);
+  static const IconData logo_firebase = IoniconsData(0xebe6);
 
   /// logo-firefox
-  static const IconData? logo_firefox = IoniconsData(0xebe7);
+  static const IconData logo_firefox = IoniconsData(0xebe7);
 
   /// logo-flickr
-  static const IconData? logo_flickr = IoniconsData(0xebe8);
+  static const IconData logo_flickr = IoniconsData(0xebe8);
 
   /// logo-foursquare
-  static const IconData? logo_foursquare = IoniconsData(0xebe9);
+  static const IconData logo_foursquare = IoniconsData(0xebe9);
 
   /// logo-github
-  static const IconData? logo_github = IoniconsData(0xebea);
+  static const IconData logo_github = IoniconsData(0xebea);
 
   /// logo-gitlab
-  static const IconData? logo_gitlab = IoniconsData(0xebeb);
+  static const IconData logo_gitlab = IoniconsData(0xebeb);
 
   /// logo-google
-  static const IconData? logo_google = IoniconsData(0xebec);
+  static const IconData logo_google = IoniconsData(0xebec);
 
   /// logo-google-playstore
-  static const IconData? logo_google_playstore = IoniconsData(0xebed);
+  static const IconData logo_google_playstore = IoniconsData(0xebed);
 
   /// logo-hackernews
-  static const IconData? logo_hackernews = IoniconsData(0xebee);
+  static const IconData logo_hackernews = IoniconsData(0xebee);
 
   /// logo-html5
-  static const IconData? logo_html5 = IoniconsData(0xebef);
+  static const IconData logo_html5 = IoniconsData(0xebef);
 
   /// logo-instagram
-  static const IconData? logo_instagram = IoniconsData(0xebf0);
+  static const IconData logo_instagram = IoniconsData(0xebf0);
 
   /// logo-ionic
-  static const IconData? logo_ionic = IoniconsData(0xebf1);
+  static const IconData logo_ionic = IoniconsData(0xebf1);
 
   /// logo-ionitron
-  static const IconData? logo_ionitron = IoniconsData(0xebf2);
+  static const IconData logo_ionitron = IoniconsData(0xebf2);
 
   /// logo-javascript
-  static const IconData? logo_javascript = IoniconsData(0xebf3);
+  static const IconData logo_javascript = IoniconsData(0xebf3);
 
   /// logo-laravel
-  static const IconData? logo_laravel = IoniconsData(0xebf4);
+  static const IconData logo_laravel = IoniconsData(0xebf4);
 
   /// logo-linkedin
-  static const IconData? logo_linkedin = IoniconsData(0xebf5);
+  static const IconData logo_linkedin = IoniconsData(0xebf5);
 
   /// logo-markdown
-  static const IconData? logo_markdown = IoniconsData(0xebf6);
+  static const IconData logo_markdown = IoniconsData(0xebf6);
 
   /// logo-mastodon
-  static const IconData? logo_mastodon = IoniconsData(0xebf7);
+  static const IconData logo_mastodon = IoniconsData(0xebf7);
 
   /// logo-medium
-  static const IconData? logo_medium = IoniconsData(0xebf8);
+  static const IconData logo_medium = IoniconsData(0xebf8);
 
   /// logo-microsoft
-  static const IconData? logo_microsoft = IoniconsData(0xebf9);
+  static const IconData logo_microsoft = IoniconsData(0xebf9);
 
   /// logo-nodejs
-  static const IconData? logo_nodejs = IoniconsData(0xebfa);
+  static const IconData logo_nodejs = IoniconsData(0xebfa);
 
   /// logo-no-smoking
-  static const IconData? logo_no_smoking = IoniconsData(0xebfb);
+  static const IconData logo_no_smoking = IoniconsData(0xebfb);
 
   /// logo-npm
-  static const IconData? logo_npm = IoniconsData(0xebfc);
+  static const IconData logo_npm = IoniconsData(0xebfc);
 
   /// logo-octocat
-  static const IconData? logo_octocat = IoniconsData(0xebfd);
+  static const IconData logo_octocat = IoniconsData(0xebfd);
 
   /// logo-paypal
-  static const IconData? logo_paypal = IoniconsData(0xebfe);
+  static const IconData logo_paypal = IoniconsData(0xebfe);
 
   /// logo-pinterest
-  static const IconData? logo_pinterest = IoniconsData(0xebff);
+  static const IconData logo_pinterest = IoniconsData(0xebff);
 
   /// logo-playstation
-  static const IconData? logo_playstation = IoniconsData(0xec00);
+  static const IconData logo_playstation = IoniconsData(0xec00);
 
   /// logo-pwa
-  static const IconData? logo_pwa = IoniconsData(0xec01);
+  static const IconData logo_pwa = IoniconsData(0xec01);
 
   /// logo-python
-  static const IconData? logo_python = IoniconsData(0xec02);
+  static const IconData logo_python = IoniconsData(0xec02);
 
   /// logo-react
-  static const IconData? logo_react = IoniconsData(0xec03);
+  static const IconData logo_react = IoniconsData(0xec03);
 
   /// logo-reddit
-  static const IconData? logo_reddit = IoniconsData(0xec04);
+  static const IconData logo_reddit = IoniconsData(0xec04);
 
   /// logo-rss
-  static const IconData? logo_rss = IoniconsData(0xec05);
+  static const IconData logo_rss = IoniconsData(0xec05);
 
   /// logo-sass
-  static const IconData? logo_sass = IoniconsData(0xec06);
+  static const IconData logo_sass = IoniconsData(0xec06);
 
   /// logo-skype
-  static const IconData? logo_skype = IoniconsData(0xec07);
+  static const IconData logo_skype = IoniconsData(0xec07);
 
   /// logo-slack
-  static const IconData? logo_slack = IoniconsData(0xec08);
+  static const IconData logo_slack = IoniconsData(0xec08);
 
   /// logo-snapchat
-  static const IconData? logo_snapchat = IoniconsData(0xec09);
+  static const IconData logo_snapchat = IoniconsData(0xec09);
 
   /// logo-soundcloud
-  static const IconData? logo_soundcloud = IoniconsData(0xec0a);
+  static const IconData logo_soundcloud = IoniconsData(0xec0a);
 
   /// logo-stackoverflow
-  static const IconData? logo_stackoverflow = IoniconsData(0xec0b);
+  static const IconData logo_stackoverflow = IoniconsData(0xec0b);
 
   /// logo-steam
-  static const IconData? logo_steam = IoniconsData(0xec0c);
+  static const IconData logo_steam = IoniconsData(0xec0c);
 
   /// logo-stencil
-  static const IconData? logo_stencil = IoniconsData(0xec0d);
+  static const IconData logo_stencil = IoniconsData(0xec0d);
 
   /// logo-tableau
-  static const IconData? logo_tableau = IoniconsData(0xec0e);
+  static const IconData logo_tableau = IoniconsData(0xec0e);
 
   /// logo-tiktok
-  static const IconData? logo_tiktok = IoniconsData(0xec0f);
+  static const IconData logo_tiktok = IoniconsData(0xec0f);
 
   /// logo-tumblr
-  static const IconData? logo_tumblr = IoniconsData(0xec10);
+  static const IconData logo_tumblr = IoniconsData(0xec10);
 
   /// logo-tux
-  static const IconData? logo_tux = IoniconsData(0xec11);
+  static const IconData logo_tux = IoniconsData(0xec11);
 
   /// logo-twitch
-  static const IconData? logo_twitch = IoniconsData(0xec12);
+  static const IconData logo_twitch = IoniconsData(0xec12);
 
   /// logo-twitter
-  static const IconData? logo_twitter = IoniconsData(0xec13);
+  static const IconData logo_twitter = IoniconsData(0xec13);
 
   /// logo-usd
-  static const IconData? logo_usd = IoniconsData(0xec14);
+  static const IconData logo_usd = IoniconsData(0xec14);
 
   /// log-out
-  static const IconData? log_out = IoniconsData(0xec15);
+  static const IconData log_out = IoniconsData(0xec15);
 
   /// log-out-outline
-  static const IconData? log_out_outline = IoniconsData(0xec16);
+  static const IconData log_out_outline = IoniconsData(0xec16);
 
   /// log-out-sharp
-  static const IconData? log_out_sharp = IoniconsData(0xec17);
+  static const IconData log_out_sharp = IoniconsData(0xec17);
 
   /// logo-venmo
-  static const IconData? logo_venmo = IoniconsData(0xec18);
+  static const IconData logo_venmo = IoniconsData(0xec18);
 
   /// logo-vercel
-  static const IconData? logo_vercel = IoniconsData(0xec19);
+  static const IconData logo_vercel = IoniconsData(0xec19);
 
   /// logo-vimeo
-  static const IconData? logo_vimeo = IoniconsData(0xec1a);
+  static const IconData logo_vimeo = IoniconsData(0xec1a);
 
   /// logo-vk
-  static const IconData? logo_vk = IoniconsData(0xec1b);
+  static const IconData logo_vk = IoniconsData(0xec1b);
 
   /// logo-vue
-  static const IconData? logo_vue = IoniconsData(0xec1c);
+  static const IconData logo_vue = IoniconsData(0xec1c);
 
   /// logo-web-component
-  static const IconData? logo_web_component = IoniconsData(0xec1d);
+  static const IconData logo_web_component = IoniconsData(0xec1d);
 
   /// logo-wechat
-  static const IconData? logo_wechat = IoniconsData(0xec1e);
+  static const IconData logo_wechat = IoniconsData(0xec1e);
 
   /// logo-whatsapp
-  static const IconData? logo_whatsapp = IoniconsData(0xec1f);
+  static const IconData logo_whatsapp = IoniconsData(0xec1f);
 
   /// logo-windows
-  static const IconData? logo_windows = IoniconsData(0xec20);
+  static const IconData logo_windows = IoniconsData(0xec20);
 
   /// logo-wordpress
-  static const IconData? logo_wordpress = IoniconsData(0xec21);
+  static const IconData logo_wordpress = IoniconsData(0xec21);
 
   /// logo-xbox
-  static const IconData? logo_xbox = IoniconsData(0xec22);
+  static const IconData logo_xbox = IoniconsData(0xec22);
 
   /// logo-xing
-  static const IconData? logo_xing = IoniconsData(0xec23);
+  static const IconData logo_xing = IoniconsData(0xec23);
 
   /// logo-yahoo
-  static const IconData? logo_yahoo = IoniconsData(0xec24);
+  static const IconData logo_yahoo = IoniconsData(0xec24);
 
   /// logo-yen
-  static const IconData? logo_yen = IoniconsData(0xec25);
+  static const IconData logo_yen = IoniconsData(0xec25);
 
   /// logo-youtube
-  static const IconData? logo_youtube = IoniconsData(0xec26);
+  static const IconData logo_youtube = IoniconsData(0xec26);
 
   /// magnet
-  static const IconData? magnet = IoniconsData(0xec27);
+  static const IconData magnet = IoniconsData(0xec27);
 
   /// magnet-outline
-  static const IconData? magnet_outline = IoniconsData(0xec28);
+  static const IconData magnet_outline = IoniconsData(0xec28);
 
   /// magnet-sharp
-  static const IconData? magnet_sharp = IoniconsData(0xec29);
+  static const IconData magnet_sharp = IoniconsData(0xec29);
 
   /// mail
-  static const IconData? mail = IoniconsData(0xec2a);
+  static const IconData mail = IoniconsData(0xec2a);
 
   /// mail-open
-  static const IconData? mail_open = IoniconsData(0xec2b);
+  static const IconData mail_open = IoniconsData(0xec2b);
 
   /// mail-open-outline
-  static const IconData? mail_open_outline = IoniconsData(0xec2c);
+  static const IconData mail_open_outline = IoniconsData(0xec2c);
 
   /// mail-open-sharp
-  static const IconData? mail_open_sharp = IoniconsData(0xec2d);
+  static const IconData mail_open_sharp = IoniconsData(0xec2d);
 
   /// mail-outline
-  static const IconData? mail_outline = IoniconsData(0xec2e);
+  static const IconData mail_outline = IoniconsData(0xec2e);
 
   /// mail-sharp
-  static const IconData? mail_sharp = IoniconsData(0xec2f);
+  static const IconData mail_sharp = IoniconsData(0xec2f);
 
   /// mail-unread
-  static const IconData? mail_unread = IoniconsData(0xec30);
+  static const IconData mail_unread = IoniconsData(0xec30);
 
   /// mail-unread-outline
-  static const IconData? mail_unread_outline = IoniconsData(0xec31);
+  static const IconData mail_unread_outline = IoniconsData(0xec31);
 
   /// mail-unread-sharp
-  static const IconData? mail_unread_sharp = IoniconsData(0xec32);
+  static const IconData mail_unread_sharp = IoniconsData(0xec32);
 
   /// male
-  static const IconData? male = IoniconsData(0xec33);
+  static const IconData male = IoniconsData(0xec33);
 
   /// male-female
-  static const IconData? male_female = IoniconsData(0xec34);
+  static const IconData male_female = IoniconsData(0xec34);
 
   /// male-female-outline
-  static const IconData? male_female_outline = IoniconsData(0xec35);
+  static const IconData male_female_outline = IoniconsData(0xec35);
 
   /// male-female-sharp
-  static const IconData? male_female_sharp = IoniconsData(0xec36);
+  static const IconData male_female_sharp = IoniconsData(0xec36);
 
   /// male-outline
-  static const IconData? male_outline = IoniconsData(0xec37);
+  static const IconData male_outline = IoniconsData(0xec37);
 
   /// male-sharp
-  static const IconData? male_sharp = IoniconsData(0xec38);
+  static const IconData male_sharp = IoniconsData(0xec38);
 
   /// man
-  static const IconData? man = IoniconsData(0xec39);
+  static const IconData man = IoniconsData(0xec39);
 
   /// man-outline
-  static const IconData? man_outline = IoniconsData(0xec3a);
+  static const IconData man_outline = IoniconsData(0xec3a);
 
   /// man-sharp
-  static const IconData? man_sharp = IoniconsData(0xec3b);
+  static const IconData man_sharp = IoniconsData(0xec3b);
 
   /// map
-  static const IconData? map = IoniconsData(0xec3c);
+  static const IconData map = IoniconsData(0xec3c);
 
   /// map-outline
-  static const IconData? map_outline = IoniconsData(0xec3d);
+  static const IconData map_outline = IoniconsData(0xec3d);
 
   /// map-sharp
-  static const IconData? map_sharp = IoniconsData(0xec3e);
+  static const IconData map_sharp = IoniconsData(0xec3e);
 
   /// medal
-  static const IconData? medal = IoniconsData(0xec3f);
+  static const IconData medal = IoniconsData(0xec3f);
 
   /// medal-outline
-  static const IconData? medal_outline = IoniconsData(0xec40);
+  static const IconData medal_outline = IoniconsData(0xec40);
 
   /// medal-sharp
-  static const IconData? medal_sharp = IoniconsData(0xec41);
+  static const IconData medal_sharp = IoniconsData(0xec41);
 
   /// medical
-  static const IconData? medical = IoniconsData(0xec42);
+  static const IconData medical = IoniconsData(0xec42);
 
   /// medical-outline
-  static const IconData? medical_outline = IoniconsData(0xec43);
+  static const IconData medical_outline = IoniconsData(0xec43);
 
   /// medical-sharp
-  static const IconData? medical_sharp = IoniconsData(0xec44);
+  static const IconData medical_sharp = IoniconsData(0xec44);
 
   /// medkit
-  static const IconData? medkit = IoniconsData(0xec45);
+  static const IconData medkit = IoniconsData(0xec45);
 
   /// medkit-outline
-  static const IconData? medkit_outline = IoniconsData(0xec46);
+  static const IconData medkit_outline = IoniconsData(0xec46);
 
   /// medkit-sharp
-  static const IconData? medkit_sharp = IoniconsData(0xec47);
+  static const IconData medkit_sharp = IoniconsData(0xec47);
 
   /// megaphone
-  static const IconData? megaphone = IoniconsData(0xec48);
+  static const IconData megaphone = IoniconsData(0xec48);
 
   /// megaphone-outline
-  static const IconData? megaphone_outline = IoniconsData(0xec49);
+  static const IconData megaphone_outline = IoniconsData(0xec49);
 
   /// megaphone-sharp
-  static const IconData? megaphone_sharp = IoniconsData(0xec4a);
+  static const IconData megaphone_sharp = IoniconsData(0xec4a);
 
   /// menu
-  static const IconData? menu = IoniconsData(0xec4b);
+  static const IconData menu = IoniconsData(0xec4b);
 
   /// menu-outline
-  static const IconData? menu_outline = IoniconsData(0xec4c);
+  static const IconData menu_outline = IoniconsData(0xec4c);
 
   /// menu-sharp
-  static const IconData? menu_sharp = IoniconsData(0xec4d);
+  static const IconData menu_sharp = IoniconsData(0xec4d);
 
   /// mic
-  static const IconData? mic = IoniconsData(0xec4e);
+  static const IconData mic = IoniconsData(0xec4e);
 
   /// mic-circle
-  static const IconData? mic_circle = IoniconsData(0xec4f);
+  static const IconData mic_circle = IoniconsData(0xec4f);
 
   /// mic-circle-outline
-  static const IconData? mic_circle_outline = IoniconsData(0xec50);
+  static const IconData mic_circle_outline = IoniconsData(0xec50);
 
   /// mic-circle-sharp
-  static const IconData? mic_circle_sharp = IoniconsData(0xec51);
+  static const IconData mic_circle_sharp = IoniconsData(0xec51);
 
   /// mic-off
-  static const IconData? mic_off = IoniconsData(0xec52);
+  static const IconData mic_off = IoniconsData(0xec52);
 
   /// mic-off-circle
-  static const IconData? mic_off_circle = IoniconsData(0xec53);
+  static const IconData mic_off_circle = IoniconsData(0xec53);
 
   /// mic-off-circle-outline
-  static const IconData? mic_off_circle_outline = IoniconsData(0xec54);
+  static const IconData mic_off_circle_outline = IoniconsData(0xec54);
 
   /// mic-off-circle-sharp
-  static const IconData? mic_off_circle_sharp = IoniconsData(0xec55);
+  static const IconData mic_off_circle_sharp = IoniconsData(0xec55);
 
   /// mic-off-outline
-  static const IconData? mic_off_outline = IoniconsData(0xec56);
+  static const IconData mic_off_outline = IoniconsData(0xec56);
 
   /// mic-off-sharp
-  static const IconData? mic_off_sharp = IoniconsData(0xec57);
+  static const IconData mic_off_sharp = IoniconsData(0xec57);
 
   /// mic-outline
-  static const IconData? mic_outline = IoniconsData(0xec58);
+  static const IconData mic_outline = IoniconsData(0xec58);
 
   /// mic-sharp
-  static const IconData? mic_sharp = IoniconsData(0xec59);
+  static const IconData mic_sharp = IoniconsData(0xec59);
 
   /// moon
-  static const IconData? moon = IoniconsData(0xec5a);
+  static const IconData moon = IoniconsData(0xec5a);
 
   /// moon-outline
-  static const IconData? moon_outline = IoniconsData(0xec5b);
+  static const IconData moon_outline = IoniconsData(0xec5b);
 
   /// moon-sharp
-  static const IconData? moon_sharp = IoniconsData(0xec5c);
+  static const IconData moon_sharp = IoniconsData(0xec5c);
 
   /// move
-  static const IconData? move = IoniconsData(0xec5d);
+  static const IconData move = IoniconsData(0xec5d);
 
   /// move-outline
-  static const IconData? move_outline = IoniconsData(0xec5e);
+  static const IconData move_outline = IoniconsData(0xec5e);
 
   /// move-sharp
-  static const IconData? move_sharp = IoniconsData(0xec5f);
+  static const IconData move_sharp = IoniconsData(0xec5f);
 
   /// musical-note
-  static const IconData? musical_note = IoniconsData(0xec60);
+  static const IconData musical_note = IoniconsData(0xec60);
 
   /// musical-note-outline
-  static const IconData? musical_note_outline = IoniconsData(0xec61);
+  static const IconData musical_note_outline = IoniconsData(0xec61);
 
   /// musical-notes
-  static const IconData? musical_notes = IoniconsData(0xec62);
+  static const IconData musical_notes = IoniconsData(0xec62);
 
   /// musical-note-sharp
-  static const IconData? musical_note_sharp = IoniconsData(0xec63);
+  static const IconData musical_note_sharp = IoniconsData(0xec63);
 
   /// musical-notes-outline
-  static const IconData? musical_notes_outline = IoniconsData(0xec64);
+  static const IconData musical_notes_outline = IoniconsData(0xec64);
 
   /// musical-notes-sharp
-  static const IconData? musical_notes_sharp = IoniconsData(0xec65);
+  static const IconData musical_notes_sharp = IoniconsData(0xec65);
 
   /// navigate
-  static const IconData? navigate = IoniconsData(0xec66);
+  static const IconData navigate = IoniconsData(0xec66);
 
   /// navigate-circle
-  static const IconData? navigate_circle = IoniconsData(0xec67);
+  static const IconData navigate_circle = IoniconsData(0xec67);
 
   /// navigate-circle-outline
-  static const IconData? navigate_circle_outline = IoniconsData(0xec68);
+  static const IconData navigate_circle_outline = IoniconsData(0xec68);
 
   /// navigate-circle-sharp
-  static const IconData? navigate_circle_sharp = IoniconsData(0xec69);
+  static const IconData navigate_circle_sharp = IoniconsData(0xec69);
 
   /// navigate-outline
-  static const IconData? navigate_outline = IoniconsData(0xec6a);
+  static const IconData navigate_outline = IoniconsData(0xec6a);
 
   /// navigate-sharp
-  static const IconData? navigate_sharp = IoniconsData(0xec6b);
+  static const IconData navigate_sharp = IoniconsData(0xec6b);
 
   /// newspaper
-  static const IconData? newspaper = IoniconsData(0xec6c);
+  static const IconData newspaper = IoniconsData(0xec6c);
 
   /// newspaper-outline
-  static const IconData? newspaper_outline = IoniconsData(0xec6d);
+  static const IconData newspaper_outline = IoniconsData(0xec6d);
 
   /// newspaper-sharp
-  static const IconData? newspaper_sharp = IoniconsData(0xec6e);
+  static const IconData newspaper_sharp = IoniconsData(0xec6e);
 
   /// notifications
-  static const IconData? notifications = IoniconsData(0xec6f);
+  static const IconData notifications = IoniconsData(0xec6f);
 
   /// notifications-circle
-  static const IconData? notifications_circle = IoniconsData(0xec70);
+  static const IconData notifications_circle = IoniconsData(0xec70);
 
   /// notifications-circle-outline
-  static const IconData? notifications_circle_outline = IoniconsData(0xec71);
+  static const IconData notifications_circle_outline = IoniconsData(0xec71);
 
   /// notifications-circle-sharp
-  static const IconData? notifications_circle_sharp = IoniconsData(0xec72);
+  static const IconData notifications_circle_sharp = IoniconsData(0xec72);
 
   /// notifications-off
-  static const IconData? notifications_off = IoniconsData(0xec73);
+  static const IconData notifications_off = IoniconsData(0xec73);
 
   /// notifications-off-circle
-  static const IconData? notifications_off_circle = IoniconsData(0xec74);
+  static const IconData notifications_off_circle = IoniconsData(0xec74);
 
   /// notifications-off-circle-outline
-  static const IconData? notifications_off_circle_outline = IoniconsData(0xec75);
+  static const IconData notifications_off_circle_outline = IoniconsData(0xec75);
 
   /// notifications-off-circle-sharp
-  static const IconData? notifications_off_circle_sharp = IoniconsData(0xec76);
+  static const IconData notifications_off_circle_sharp = IoniconsData(0xec76);
 
   /// notifications-off-outline
-  static const IconData? notifications_off_outline = IoniconsData(0xec77);
+  static const IconData notifications_off_outline = IoniconsData(0xec77);
 
   /// notifications-off-sharp
-  static const IconData? notifications_off_sharp = IoniconsData(0xec78);
+  static const IconData notifications_off_sharp = IoniconsData(0xec78);
 
   /// notifications-outline
-  static const IconData? notifications_outline = IoniconsData(0xec79);
+  static const IconData notifications_outline = IoniconsData(0xec79);
 
   /// notifications-sharp
-  static const IconData? notifications_sharp = IoniconsData(0xec7a);
+  static const IconData notifications_sharp = IoniconsData(0xec7a);
 
   /// nuclear
-  static const IconData? nuclear = IoniconsData(0xec7b);
+  static const IconData nuclear = IoniconsData(0xec7b);
 
   /// nuclear-outline
-  static const IconData? nuclear_outline = IoniconsData(0xec7c);
+  static const IconData nuclear_outline = IoniconsData(0xec7c);
 
   /// nuclear-sharp
-  static const IconData? nuclear_sharp = IoniconsData(0xec7d);
+  static const IconData nuclear_sharp = IoniconsData(0xec7d);
 
   /// nutrition
-  static const IconData? nutrition = IoniconsData(0xec7e);
+  static const IconData nutrition = IoniconsData(0xec7e);
 
   /// nutrition-outline
-  static const IconData? nutrition_outline = IoniconsData(0xec7f);
+  static const IconData nutrition_outline = IoniconsData(0xec7f);
 
   /// nutrition-sharp
-  static const IconData? nutrition_sharp = IoniconsData(0xec80);
+  static const IconData nutrition_sharp = IoniconsData(0xec80);
 
   /// open
-  static const IconData? open = IoniconsData(0xec81);
+  static const IconData open = IoniconsData(0xec81);
 
   /// open-outline
-  static const IconData? open_outline = IoniconsData(0xec82);
+  static const IconData open_outline = IoniconsData(0xec82);
 
   /// open-sharp
-  static const IconData? open_sharp = IoniconsData(0xec83);
+  static const IconData open_sharp = IoniconsData(0xec83);
 
   /// options
-  static const IconData? options = IoniconsData(0xec84);
+  static const IconData options = IoniconsData(0xec84);
 
   /// options-outline
-  static const IconData? options_outline = IoniconsData(0xec85);
+  static const IconData options_outline = IoniconsData(0xec85);
 
   /// options-sharp
-  static const IconData? options_sharp = IoniconsData(0xec86);
+  static const IconData options_sharp = IoniconsData(0xec86);
 
   /// paper-plane
-  static const IconData? paper_plane = IoniconsData(0xec87);
+  static const IconData paper_plane = IoniconsData(0xec87);
 
   /// paper-plane-outline
-  static const IconData? paper_plane_outline = IoniconsData(0xec88);
+  static const IconData paper_plane_outline = IoniconsData(0xec88);
 
   /// paper-plane-sharp
-  static const IconData? paper_plane_sharp = IoniconsData(0xec89);
+  static const IconData paper_plane_sharp = IoniconsData(0xec89);
 
   /// partly-sunny
-  static const IconData? partly_sunny = IoniconsData(0xec8a);
+  static const IconData partly_sunny = IoniconsData(0xec8a);
 
   /// partly-sunny-outline
-  static const IconData? partly_sunny_outline = IoniconsData(0xec8b);
+  static const IconData partly_sunny_outline = IoniconsData(0xec8b);
 
   /// partly-sunny-sharp
-  static const IconData? partly_sunny_sharp = IoniconsData(0xec8c);
+  static const IconData partly_sunny_sharp = IoniconsData(0xec8c);
 
   /// pause
-  static const IconData? pause = IoniconsData(0xec8d);
+  static const IconData pause = IoniconsData(0xec8d);
 
   /// pause-circle
-  static const IconData? pause_circle = IoniconsData(0xec8e);
+  static const IconData pause_circle = IoniconsData(0xec8e);
 
   /// pause-circle-outline
-  static const IconData? pause_circle_outline = IoniconsData(0xec8f);
+  static const IconData pause_circle_outline = IoniconsData(0xec8f);
 
   /// pause-circle-sharp
-  static const IconData? pause_circle_sharp = IoniconsData(0xec90);
+  static const IconData pause_circle_sharp = IoniconsData(0xec90);
 
   /// pause-outline
-  static const IconData? pause_outline = IoniconsData(0xec91);
+  static const IconData pause_outline = IoniconsData(0xec91);
 
   /// pause-sharp
-  static const IconData? pause_sharp = IoniconsData(0xec92);
+  static const IconData pause_sharp = IoniconsData(0xec92);
 
   /// paw
-  static const IconData? paw = IoniconsData(0xec93);
+  static const IconData paw = IoniconsData(0xec93);
 
   /// paw-outline
-  static const IconData? paw_outline = IoniconsData(0xec94);
+  static const IconData paw_outline = IoniconsData(0xec94);
 
   /// paw-sharp
-  static const IconData? paw_sharp = IoniconsData(0xec95);
+  static const IconData paw_sharp = IoniconsData(0xec95);
 
   /// pencil
-  static const IconData? pencil = IoniconsData(0xec96);
+  static const IconData pencil = IoniconsData(0xec96);
 
   /// pencil-outline
-  static const IconData? pencil_outline = IoniconsData(0xec97);
+  static const IconData pencil_outline = IoniconsData(0xec97);
 
   /// pencil-sharp
-  static const IconData? pencil_sharp = IoniconsData(0xec98);
+  static const IconData pencil_sharp = IoniconsData(0xec98);
 
   /// people
-  static const IconData? people = IoniconsData(0xec99);
+  static const IconData people = IoniconsData(0xec99);
 
   /// people-circle
-  static const IconData? people_circle = IoniconsData(0xec9a);
+  static const IconData people_circle = IoniconsData(0xec9a);
 
   /// people-circle-outline
-  static const IconData? people_circle_outline = IoniconsData(0xec9b);
+  static const IconData people_circle_outline = IoniconsData(0xec9b);
 
   /// people-circle-sharp
-  static const IconData? people_circle_sharp = IoniconsData(0xec9c);
+  static const IconData people_circle_sharp = IoniconsData(0xec9c);
 
   /// people-outline
-  static const IconData? people_outline = IoniconsData(0xec9d);
+  static const IconData people_outline = IoniconsData(0xec9d);
 
   /// people-sharp
-  static const IconData? people_sharp = IoniconsData(0xec9e);
+  static const IconData people_sharp = IoniconsData(0xec9e);
 
   /// person
-  static const IconData? person = IoniconsData(0xec9f);
+  static const IconData person = IoniconsData(0xec9f);
 
   /// person-add
-  static const IconData? person_add = IoniconsData(0xeca0);
+  static const IconData person_add = IoniconsData(0xeca0);
 
   /// person-add-outline
-  static const IconData? person_add_outline = IoniconsData(0xeca1);
+  static const IconData person_add_outline = IoniconsData(0xeca1);
 
   /// person-add-sharp
-  static const IconData? person_add_sharp = IoniconsData(0xeca2);
+  static const IconData person_add_sharp = IoniconsData(0xeca2);
 
   /// person-circle
-  static const IconData? person_circle = IoniconsData(0xeca3);
+  static const IconData person_circle = IoniconsData(0xeca3);
 
   /// person-circle-outline
-  static const IconData? person_circle_outline = IoniconsData(0xeca4);
+  static const IconData person_circle_outline = IoniconsData(0xeca4);
 
   /// person-circle-sharp
-  static const IconData? person_circle_sharp = IoniconsData(0xeca5);
+  static const IconData person_circle_sharp = IoniconsData(0xeca5);
 
   /// person-outline
-  static const IconData? person_outline = IoniconsData(0xeca6);
+  static const IconData person_outline = IoniconsData(0xeca6);
 
   /// person-remove
-  static const IconData? person_remove = IoniconsData(0xeca7);
+  static const IconData person_remove = IoniconsData(0xeca7);
 
   /// person-remove-outline
-  static const IconData? person_remove_outline = IoniconsData(0xeca8);
+  static const IconData person_remove_outline = IoniconsData(0xeca8);
 
   /// person-remove-sharp
-  static const IconData? person_remove_sharp = IoniconsData(0xeca9);
+  static const IconData person_remove_sharp = IoniconsData(0xeca9);
 
   /// person-sharp
-  static const IconData? person_sharp = IoniconsData(0xecaa);
+  static const IconData person_sharp = IoniconsData(0xecaa);
 
   /// phone-landscape
-  static const IconData? phone_landscape = IoniconsData(0xecab);
+  static const IconData phone_landscape = IoniconsData(0xecab);
 
   /// phone-landscape-outline
-  static const IconData? phone_landscape_outline = IoniconsData(0xecac);
+  static const IconData phone_landscape_outline = IoniconsData(0xecac);
 
   /// phone-landscape-sharp
-  static const IconData? phone_landscape_sharp = IoniconsData(0xecad);
+  static const IconData phone_landscape_sharp = IoniconsData(0xecad);
 
   /// phone-portrait
-  static const IconData? phone_portrait = IoniconsData(0xecae);
+  static const IconData phone_portrait = IoniconsData(0xecae);
 
   /// phone-portrait-outline
-  static const IconData? phone_portrait_outline = IoniconsData(0xecaf);
+  static const IconData phone_portrait_outline = IoniconsData(0xecaf);
 
   /// phone-portrait-sharp
-  static const IconData? phone_portrait_sharp = IoniconsData(0xecb0);
+  static const IconData phone_portrait_sharp = IoniconsData(0xecb0);
 
   /// pie-chart
-  static const IconData? pie_chart = IoniconsData(0xecb1);
+  static const IconData pie_chart = IoniconsData(0xecb1);
 
   /// pie-chart-outline
-  static const IconData? pie_chart_outline = IoniconsData(0xecb2);
+  static const IconData pie_chart_outline = IoniconsData(0xecb2);
 
   /// pie-chart-sharp
-  static const IconData? pie_chart_sharp = IoniconsData(0xecb3);
+  static const IconData pie_chart_sharp = IoniconsData(0xecb3);
 
   /// pin
-  static const IconData? pin = IoniconsData(0xecb4);
+  static const IconData pin = IoniconsData(0xecb4);
 
   /// pin-outline
-  static const IconData? pin_outline = IoniconsData(0xecb5);
+  static const IconData pin_outline = IoniconsData(0xecb5);
 
   /// pin-sharp
-  static const IconData? pin_sharp = IoniconsData(0xecb6);
+  static const IconData pin_sharp = IoniconsData(0xecb6);
 
   /// pint
-  static const IconData? pint = IoniconsData(0xecb7);
+  static const IconData pint = IoniconsData(0xecb7);
 
   /// pint-outline
-  static const IconData? pint_outline = IoniconsData(0xecb8);
+  static const IconData pint_outline = IoniconsData(0xecb8);
 
   /// pint-sharp
-  static const IconData? pint_sharp = IoniconsData(0xecb9);
+  static const IconData pint_sharp = IoniconsData(0xecb9);
 
   /// pizza
-  static const IconData? pizza = IoniconsData(0xecba);
+  static const IconData pizza = IoniconsData(0xecba);
 
   /// pizza-outline
-  static const IconData? pizza_outline = IoniconsData(0xecbb);
+  static const IconData pizza_outline = IoniconsData(0xecbb);
 
   /// pizza-sharp
-  static const IconData? pizza_sharp = IoniconsData(0xecbc);
+  static const IconData pizza_sharp = IoniconsData(0xecbc);
 
   /// planet
-  static const IconData? planet = IoniconsData(0xecbd);
+  static const IconData planet = IoniconsData(0xecbd);
 
   /// planet-outline
-  static const IconData? planet_outline = IoniconsData(0xecbe);
+  static const IconData planet_outline = IoniconsData(0xecbe);
 
   /// planet-sharp
-  static const IconData? planet_sharp = IoniconsData(0xecbf);
+  static const IconData planet_sharp = IoniconsData(0xecbf);
 
   /// play
-  static const IconData? play = IoniconsData(0xecc0);
+  static const IconData play = IoniconsData(0xecc0);
 
   /// play-back
-  static const IconData? play_back = IoniconsData(0xecc1);
+  static const IconData play_back = IoniconsData(0xecc1);
 
   /// play-back-circle
-  static const IconData? play_back_circle = IoniconsData(0xecc2);
+  static const IconData play_back_circle = IoniconsData(0xecc2);
 
   /// play-back-circle-outline
-  static const IconData? play_back_circle_outline = IoniconsData(0xecc3);
+  static const IconData play_back_circle_outline = IoniconsData(0xecc3);
 
   /// play-back-circle-sharp
-  static const IconData? play_back_circle_sharp = IoniconsData(0xecc4);
+  static const IconData play_back_circle_sharp = IoniconsData(0xecc4);
 
   /// play-back-outline
-  static const IconData? play_back_outline = IoniconsData(0xecc5);
+  static const IconData play_back_outline = IoniconsData(0xecc5);
 
   /// play-back-sharp
-  static const IconData? play_back_sharp = IoniconsData(0xecc6);
+  static const IconData play_back_sharp = IoniconsData(0xecc6);
 
   /// play-circle
-  static const IconData? play_circle = IoniconsData(0xecc7);
+  static const IconData play_circle = IoniconsData(0xecc7);
 
   /// play-circle-outline
-  static const IconData? play_circle_outline = IoniconsData(0xecc8);
+  static const IconData play_circle_outline = IoniconsData(0xecc8);
 
   /// play-circle-sharp
-  static const IconData? play_circle_sharp = IoniconsData(0xecc9);
+  static const IconData play_circle_sharp = IoniconsData(0xecc9);
 
   /// play-forward
-  static const IconData? play_forward = IoniconsData(0xecca);
+  static const IconData play_forward = IoniconsData(0xecca);
 
   /// play-forward-circle
-  static const IconData? play_forward_circle = IoniconsData(0xeccb);
+  static const IconData play_forward_circle = IoniconsData(0xeccb);
 
   /// play-forward-circle-outline
-  static const IconData? play_forward_circle_outline = IoniconsData(0xeccc);
+  static const IconData play_forward_circle_outline = IoniconsData(0xeccc);
 
   /// play-forward-circle-sharp
-  static const IconData? play_forward_circle_sharp = IoniconsData(0xeccd);
+  static const IconData play_forward_circle_sharp = IoniconsData(0xeccd);
 
   /// play-forward-outline
-  static const IconData? play_forward_outline = IoniconsData(0xecce);
+  static const IconData play_forward_outline = IoniconsData(0xecce);
 
   /// play-forward-sharp
-  static const IconData? play_forward_sharp = IoniconsData(0xeccf);
+  static const IconData play_forward_sharp = IoniconsData(0xeccf);
 
   /// play-outline
-  static const IconData? play_outline = IoniconsData(0xecd0);
+  static const IconData play_outline = IoniconsData(0xecd0);
 
   /// play-sharp
-  static const IconData? play_sharp = IoniconsData(0xecd1);
+  static const IconData play_sharp = IoniconsData(0xecd1);
 
   /// play-skip-back
-  static const IconData? play_skip_back = IoniconsData(0xecd2);
+  static const IconData play_skip_back = IoniconsData(0xecd2);
 
   /// play-skip-back-circle
-  static const IconData? play_skip_back_circle = IoniconsData(0xecd3);
+  static const IconData play_skip_back_circle = IoniconsData(0xecd3);
 
   /// play-skip-back-circle-outline
-  static const IconData? play_skip_back_circle_outline = IoniconsData(0xecd4);
+  static const IconData play_skip_back_circle_outline = IoniconsData(0xecd4);
 
   /// play-skip-back-circle-sharp
-  static const IconData? play_skip_back_circle_sharp = IoniconsData(0xecd5);
+  static const IconData play_skip_back_circle_sharp = IoniconsData(0xecd5);
 
   /// play-skip-back-outline
-  static const IconData? play_skip_back_outline = IoniconsData(0xecd6);
+  static const IconData play_skip_back_outline = IoniconsData(0xecd6);
 
   /// play-skip-back-sharp
-  static const IconData? play_skip_back_sharp = IoniconsData(0xecd7);
+  static const IconData play_skip_back_sharp = IoniconsData(0xecd7);
 
   /// play-skip-forward
-  static const IconData? play_skip_forward = IoniconsData(0xecd8);
+  static const IconData play_skip_forward = IoniconsData(0xecd8);
 
   /// play-skip-forward-circle
-  static const IconData? play_skip_forward_circle = IoniconsData(0xecd9);
+  static const IconData play_skip_forward_circle = IoniconsData(0xecd9);
 
   /// play-skip-forward-circle-outline
-  static const IconData? play_skip_forward_circle_outline = IoniconsData(0xecda);
+  static const IconData play_skip_forward_circle_outline = IoniconsData(0xecda);
 
   /// play-skip-forward-circle-sharp
-  static const IconData? play_skip_forward_circle_sharp = IoniconsData(0xecdb);
+  static const IconData play_skip_forward_circle_sharp = IoniconsData(0xecdb);
 
   /// play-skip-forward-outline
-  static const IconData? play_skip_forward_outline = IoniconsData(0xecdc);
+  static const IconData play_skip_forward_outline = IoniconsData(0xecdc);
 
   /// play-skip-forward-sharp
-  static const IconData? play_skip_forward_sharp = IoniconsData(0xecdd);
+  static const IconData play_skip_forward_sharp = IoniconsData(0xecdd);
 
   /// podium
-  static const IconData? podium = IoniconsData(0xecde);
+  static const IconData podium = IoniconsData(0xecde);
 
   /// podium-outline
-  static const IconData? podium_outline = IoniconsData(0xecdf);
+  static const IconData podium_outline = IoniconsData(0xecdf);
 
   /// podium-sharp
-  static const IconData? podium_sharp = IoniconsData(0xece0);
+  static const IconData podium_sharp = IoniconsData(0xece0);
 
   /// power
-  static const IconData? power = IoniconsData(0xece1);
+  static const IconData power = IoniconsData(0xece1);
 
   /// power-outline
-  static const IconData? power_outline = IoniconsData(0xece2);
+  static const IconData power_outline = IoniconsData(0xece2);
 
   /// power-sharp
-  static const IconData? power_sharp = IoniconsData(0xece3);
+  static const IconData power_sharp = IoniconsData(0xece3);
 
   /// pricetag
-  static const IconData? pricetag = IoniconsData(0xece4);
+  static const IconData pricetag = IoniconsData(0xece4);
 
   /// pricetag-outline
-  static const IconData? pricetag_outline = IoniconsData(0xece5);
+  static const IconData pricetag_outline = IoniconsData(0xece5);
 
   /// pricetags
-  static const IconData? pricetags = IoniconsData(0xece6);
+  static const IconData pricetags = IoniconsData(0xece6);
 
   /// pricetag-sharp
-  static const IconData? pricetag_sharp = IoniconsData(0xece7);
+  static const IconData pricetag_sharp = IoniconsData(0xece7);
 
   /// pricetags-outline
-  static const IconData? pricetags_outline = IoniconsData(0xece8);
+  static const IconData pricetags_outline = IoniconsData(0xece8);
 
   /// pricetags-sharp
-  static const IconData? pricetags_sharp = IoniconsData(0xece9);
+  static const IconData pricetags_sharp = IoniconsData(0xece9);
 
   /// print
-  static const IconData? print = IoniconsData(0xecea);
+  static const IconData print = IoniconsData(0xecea);
 
   /// print-outline
-  static const IconData? print_outline = IoniconsData(0xeceb);
+  static const IconData print_outline = IoniconsData(0xeceb);
 
   /// print-sharp
-  static const IconData? print_sharp = IoniconsData(0xecec);
+  static const IconData print_sharp = IoniconsData(0xecec);
 
   /// prism
-  static const IconData? prism = IoniconsData(0xeced);
+  static const IconData prism = IoniconsData(0xeced);
 
   /// prism-outline
-  static const IconData? prism_outline = IoniconsData(0xecee);
+  static const IconData prism_outline = IoniconsData(0xecee);
 
   /// prism-sharp
-  static const IconData? prism_sharp = IoniconsData(0xecef);
+  static const IconData prism_sharp = IoniconsData(0xecef);
 
   /// pulse
-  static const IconData? pulse = IoniconsData(0xecf0);
+  static const IconData pulse = IoniconsData(0xecf0);
 
   /// pulse-outline
-  static const IconData? pulse_outline = IoniconsData(0xecf1);
+  static const IconData pulse_outline = IoniconsData(0xecf1);
 
   /// pulse-sharp
-  static const IconData? pulse_sharp = IoniconsData(0xecf2);
+  static const IconData pulse_sharp = IoniconsData(0xecf2);
 
   /// push
-  static const IconData? push = IoniconsData(0xecf3);
+  static const IconData push = IoniconsData(0xecf3);
 
   /// push-outline
-  static const IconData? push_outline = IoniconsData(0xecf4);
+  static const IconData push_outline = IoniconsData(0xecf4);
 
   /// push-sharp
-  static const IconData? push_sharp = IoniconsData(0xecf5);
+  static const IconData push_sharp = IoniconsData(0xecf5);
 
   /// qr-code
-  static const IconData? qr_code = IoniconsData(0xecf6);
+  static const IconData qr_code = IoniconsData(0xecf6);
 
   /// qr-code-outline
-  static const IconData? qr_code_outline = IoniconsData(0xecf7);
+  static const IconData qr_code_outline = IoniconsData(0xecf7);
 
   /// qr-code-sharp
-  static const IconData? qr_code_sharp = IoniconsData(0xecf8);
+  static const IconData qr_code_sharp = IoniconsData(0xecf8);
 
   /// radio
-  static const IconData? radio = IoniconsData(0xecf9);
+  static const IconData radio = IoniconsData(0xecf9);
 
   /// radio-button-off
-  static const IconData? radio_button_off = IoniconsData(0xecfa);
+  static const IconData radio_button_off = IoniconsData(0xecfa);
 
   /// radio-button-off-outline
-  static const IconData? radio_button_off_outline = IoniconsData(0xecfb);
+  static const IconData radio_button_off_outline = IoniconsData(0xecfb);
 
   /// radio-button-off-sharp
-  static const IconData? radio_button_off_sharp = IoniconsData(0xecfc);
+  static const IconData radio_button_off_sharp = IoniconsData(0xecfc);
 
   /// radio-button-on
-  static const IconData? radio_button_on = IoniconsData(0xecfd);
+  static const IconData radio_button_on = IoniconsData(0xecfd);
 
   /// radio-button-on-outline
-  static const IconData? radio_button_on_outline = IoniconsData(0xecfe);
+  static const IconData radio_button_on_outline = IoniconsData(0xecfe);
 
   /// radio-button-on-sharp
-  static const IconData? radio_button_on_sharp = IoniconsData(0xecff);
+  static const IconData radio_button_on_sharp = IoniconsData(0xecff);
 
   /// radio-outline
-  static const IconData? radio_outline = IoniconsData(0xed00);
+  static const IconData radio_outline = IoniconsData(0xed00);
 
   /// radio-sharp
-  static const IconData? radio_sharp = IoniconsData(0xed01);
+  static const IconData radio_sharp = IoniconsData(0xed01);
 
   /// rainy
-  static const IconData? rainy = IoniconsData(0xed02);
+  static const IconData rainy = IoniconsData(0xed02);
 
   /// rainy-outline
-  static const IconData? rainy_outline = IoniconsData(0xed03);
+  static const IconData rainy_outline = IoniconsData(0xed03);
 
   /// rainy-sharp
-  static const IconData? rainy_sharp = IoniconsData(0xed04);
+  static const IconData rainy_sharp = IoniconsData(0xed04);
 
   /// reader
-  static const IconData? reader = IoniconsData(0xed05);
+  static const IconData reader = IoniconsData(0xed05);
 
   /// reader-outline
-  static const IconData? reader_outline = IoniconsData(0xed06);
+  static const IconData reader_outline = IoniconsData(0xed06);
 
   /// reader-sharp
-  static const IconData? reader_sharp = IoniconsData(0xed07);
+  static const IconData reader_sharp = IoniconsData(0xed07);
 
   /// receipt
-  static const IconData? receipt = IoniconsData(0xed08);
+  static const IconData receipt = IoniconsData(0xed08);
 
   /// receipt-outline
-  static const IconData? receipt_outline = IoniconsData(0xed09);
+  static const IconData receipt_outline = IoniconsData(0xed09);
 
   /// receipt-sharp
-  static const IconData? receipt_sharp = IoniconsData(0xed0a);
+  static const IconData receipt_sharp = IoniconsData(0xed0a);
 
   /// recording
-  static const IconData? recording = IoniconsData(0xed0b);
+  static const IconData recording = IoniconsData(0xed0b);
 
   /// recording-outline
-  static const IconData? recording_outline = IoniconsData(0xed0c);
+  static const IconData recording_outline = IoniconsData(0xed0c);
 
   /// recording-sharp
-  static const IconData? recording_sharp = IoniconsData(0xed0d);
+  static const IconData recording_sharp = IoniconsData(0xed0d);
 
   /// refresh
-  static const IconData? refresh = IoniconsData(0xed0e);
+  static const IconData refresh = IoniconsData(0xed0e);
 
   /// refresh-circle
-  static const IconData? refresh_circle = IoniconsData(0xed0f);
+  static const IconData refresh_circle = IoniconsData(0xed0f);
 
   /// refresh-circle-outline
-  static const IconData? refresh_circle_outline = IoniconsData(0xed10);
+  static const IconData refresh_circle_outline = IoniconsData(0xed10);
 
   /// refresh-circle-sharp
-  static const IconData? refresh_circle_sharp = IoniconsData(0xed11);
+  static const IconData refresh_circle_sharp = IoniconsData(0xed11);
 
   /// refresh-outline
-  static const IconData? refresh_outline = IoniconsData(0xed12);
+  static const IconData refresh_outline = IoniconsData(0xed12);
 
   /// refresh-sharp
-  static const IconData? refresh_sharp = IoniconsData(0xed13);
+  static const IconData refresh_sharp = IoniconsData(0xed13);
 
   /// reload
-  static const IconData? reload = IoniconsData(0xed14);
+  static const IconData reload = IoniconsData(0xed14);
 
   /// reload-circle
-  static const IconData? reload_circle = IoniconsData(0xed15);
+  static const IconData reload_circle = IoniconsData(0xed15);
 
   /// reload-circle-outline
-  static const IconData? reload_circle_outline = IoniconsData(0xed16);
+  static const IconData reload_circle_outline = IoniconsData(0xed16);
 
   /// reload-circle-sharp
-  static const IconData? reload_circle_sharp = IoniconsData(0xed17);
+  static const IconData reload_circle_sharp = IoniconsData(0xed17);
 
   /// reload-outline
-  static const IconData? reload_outline = IoniconsData(0xed18);
+  static const IconData reload_outline = IoniconsData(0xed18);
 
   /// reload-sharp
-  static const IconData? reload_sharp = IoniconsData(0xed19);
+  static const IconData reload_sharp = IoniconsData(0xed19);
 
   /// remove
-  static const IconData? remove = IoniconsData(0xed1a);
+  static const IconData remove = IoniconsData(0xed1a);
 
   /// remove-circle
-  static const IconData? remove_circle = IoniconsData(0xed1b);
+  static const IconData remove_circle = IoniconsData(0xed1b);
 
   /// remove-circle-outline
-  static const IconData? remove_circle_outline = IoniconsData(0xed1c);
+  static const IconData remove_circle_outline = IoniconsData(0xed1c);
 
   /// remove-circle-sharp
-  static const IconData? remove_circle_sharp = IoniconsData(0xed1d);
+  static const IconData remove_circle_sharp = IoniconsData(0xed1d);
 
   /// remove-outline
-  static const IconData? remove_outline = IoniconsData(0xed1e);
+  static const IconData remove_outline = IoniconsData(0xed1e);
 
   /// remove-sharp
-  static const IconData? remove_sharp = IoniconsData(0xed1f);
+  static const IconData remove_sharp = IoniconsData(0xed1f);
 
   /// reorder-four
-  static const IconData? reorder_four = IoniconsData(0xed20);
+  static const IconData reorder_four = IoniconsData(0xed20);
 
   /// reorder-four-outline
-  static const IconData? reorder_four_outline = IoniconsData(0xed21);
+  static const IconData reorder_four_outline = IoniconsData(0xed21);
 
   /// reorder-four-sharp
-  static const IconData? reorder_four_sharp = IoniconsData(0xed22);
+  static const IconData reorder_four_sharp = IoniconsData(0xed22);
 
   /// reorder-three
-  static const IconData? reorder_three = IoniconsData(0xed23);
+  static const IconData reorder_three = IoniconsData(0xed23);
 
   /// reorder-three-outline
-  static const IconData? reorder_three_outline = IoniconsData(0xed24);
+  static const IconData reorder_three_outline = IoniconsData(0xed24);
 
   /// reorder-three-sharp
-  static const IconData? reorder_three_sharp = IoniconsData(0xed25);
+  static const IconData reorder_three_sharp = IoniconsData(0xed25);
 
   /// reorder-two
-  static const IconData? reorder_two = IoniconsData(0xed26);
+  static const IconData reorder_two = IoniconsData(0xed26);
 
   /// reorder-two-outline
-  static const IconData? reorder_two_outline = IoniconsData(0xed27);
+  static const IconData reorder_two_outline = IoniconsData(0xed27);
 
   /// reorder-two-sharp
-  static const IconData? reorder_two_sharp = IoniconsData(0xed28);
+  static const IconData reorder_two_sharp = IoniconsData(0xed28);
 
   /// repeat
-  static const IconData? repeat = IoniconsData(0xed29);
+  static const IconData repeat = IoniconsData(0xed29);
 
   /// repeat-outline
-  static const IconData? repeat_outline = IoniconsData(0xed2a);
+  static const IconData repeat_outline = IoniconsData(0xed2a);
 
   /// repeat-sharp
-  static const IconData? repeat_sharp = IoniconsData(0xed2b);
+  static const IconData repeat_sharp = IoniconsData(0xed2b);
 
   /// resize
-  static const IconData? resize = IoniconsData(0xed2c);
+  static const IconData resize = IoniconsData(0xed2c);
 
   /// resize-outline
-  static const IconData? resize_outline = IoniconsData(0xed2d);
+  static const IconData resize_outline = IoniconsData(0xed2d);
 
   /// resize-sharp
-  static const IconData? resize_sharp = IoniconsData(0xed2e);
+  static const IconData resize_sharp = IoniconsData(0xed2e);
 
   /// restaurant
-  static const IconData? restaurant = IoniconsData(0xed2f);
+  static const IconData restaurant = IoniconsData(0xed2f);
 
   /// restaurant-outline
-  static const IconData? restaurant_outline = IoniconsData(0xed30);
+  static const IconData restaurant_outline = IoniconsData(0xed30);
 
   /// restaurant-sharp
-  static const IconData? restaurant_sharp = IoniconsData(0xed31);
+  static const IconData restaurant_sharp = IoniconsData(0xed31);
 
   /// return-down-back
-  static const IconData? return_down_back = IoniconsData(0xed32);
+  static const IconData return_down_back = IoniconsData(0xed32);
 
   /// return-down-back-outline
-  static const IconData? return_down_back_outline = IoniconsData(0xed33);
+  static const IconData return_down_back_outline = IoniconsData(0xed33);
 
   /// return-down-back-sharp
-  static const IconData? return_down_back_sharp = IoniconsData(0xed34);
+  static const IconData return_down_back_sharp = IoniconsData(0xed34);
 
   /// return-down-forward
-  static const IconData? return_down_forward = IoniconsData(0xed35);
+  static const IconData return_down_forward = IoniconsData(0xed35);
 
   /// return-down-forward-outline
-  static const IconData? return_down_forward_outline = IoniconsData(0xed36);
+  static const IconData return_down_forward_outline = IoniconsData(0xed36);
 
   /// return-down-forward-sharp
-  static const IconData? return_down_forward_sharp = IoniconsData(0xed37);
+  static const IconData return_down_forward_sharp = IoniconsData(0xed37);
 
   /// return-up-back
-  static const IconData? return_up_back = IoniconsData(0xed38);
+  static const IconData return_up_back = IoniconsData(0xed38);
 
   /// return-up-back-outline
-  static const IconData? return_up_back_outline = IoniconsData(0xed39);
+  static const IconData return_up_back_outline = IoniconsData(0xed39);
 
   /// return-up-back-sharp
-  static const IconData? return_up_back_sharp = IoniconsData(0xed3a);
+  static const IconData return_up_back_sharp = IoniconsData(0xed3a);
 
   /// return-up-forward
-  static const IconData? return_up_forward = IoniconsData(0xed3b);
+  static const IconData return_up_forward = IoniconsData(0xed3b);
 
   /// return-up-forward-outline
-  static const IconData? return_up_forward_outline = IoniconsData(0xed3c);
+  static const IconData return_up_forward_outline = IoniconsData(0xed3c);
 
   /// return-up-forward-sharp
-  static const IconData? return_up_forward_sharp = IoniconsData(0xed3d);
+  static const IconData return_up_forward_sharp = IoniconsData(0xed3d);
 
   /// ribbon
-  static const IconData? ribbon = IoniconsData(0xed3e);
+  static const IconData ribbon = IoniconsData(0xed3e);
 
   /// ribbon-outline
-  static const IconData? ribbon_outline = IoniconsData(0xed3f);
+  static const IconData ribbon_outline = IoniconsData(0xed3f);
 
   /// ribbon-sharp
-  static const IconData? ribbon_sharp = IoniconsData(0xed40);
+  static const IconData ribbon_sharp = IoniconsData(0xed40);
 
   /// rocket
-  static const IconData? rocket = IoniconsData(0xed41);
+  static const IconData rocket = IoniconsData(0xed41);
 
   /// rocket-outline
-  static const IconData? rocket_outline = IoniconsData(0xed42);
+  static const IconData rocket_outline = IoniconsData(0xed42);
 
   /// rocket-sharp
-  static const IconData? rocket_sharp = IoniconsData(0xed43);
+  static const IconData rocket_sharp = IoniconsData(0xed43);
 
   /// rose
-  static const IconData? rose = IoniconsData(0xed44);
+  static const IconData rose = IoniconsData(0xed44);
 
   /// rose-outline
-  static const IconData? rose_outline = IoniconsData(0xed45);
+  static const IconData rose_outline = IoniconsData(0xed45);
 
   /// rose-sharp
-  static const IconData? rose_sharp = IoniconsData(0xed46);
+  static const IconData rose_sharp = IoniconsData(0xed46);
 
   /// sad
-  static const IconData? sad = IoniconsData(0xed47);
+  static const IconData sad = IoniconsData(0xed47);
 
   /// sad-outline
-  static const IconData? sad_outline = IoniconsData(0xed48);
+  static const IconData sad_outline = IoniconsData(0xed48);
 
   /// sad-sharp
-  static const IconData? sad_sharp = IoniconsData(0xed49);
+  static const IconData sad_sharp = IoniconsData(0xed49);
 
   /// save
-  static const IconData? save = IoniconsData(0xed4a);
+  static const IconData save = IoniconsData(0xed4a);
 
   /// save-outline
-  static const IconData? save_outline = IoniconsData(0xed4b);
+  static const IconData save_outline = IoniconsData(0xed4b);
 
   /// save-sharp
-  static const IconData? save_sharp = IoniconsData(0xed4c);
+  static const IconData save_sharp = IoniconsData(0xed4c);
 
   /// scale
-  static const IconData? scale = IoniconsData(0xed4d);
+  static const IconData scale = IoniconsData(0xed4d);
 
   /// scale-outline
-  static const IconData? scale_outline = IoniconsData(0xed4e);
+  static const IconData scale_outline = IoniconsData(0xed4e);
 
   /// scale-sharp
-  static const IconData? scale_sharp = IoniconsData(0xed4f);
+  static const IconData scale_sharp = IoniconsData(0xed4f);
 
   /// scan
-  static const IconData? scan = IoniconsData(0xed50);
+  static const IconData scan = IoniconsData(0xed50);
 
   /// scan-circle
-  static const IconData? scan_circle = IoniconsData(0xed51);
+  static const IconData scan_circle = IoniconsData(0xed51);
 
   /// scan-circle-outline
-  static const IconData? scan_circle_outline = IoniconsData(0xed52);
+  static const IconData scan_circle_outline = IoniconsData(0xed52);
 
   /// scan-circle-sharp
-  static const IconData? scan_circle_sharp = IoniconsData(0xed53);
+  static const IconData scan_circle_sharp = IoniconsData(0xed53);
 
   /// scan-outline
-  static const IconData? scan_outline = IoniconsData(0xed54);
+  static const IconData scan_outline = IoniconsData(0xed54);
 
   /// scan-sharp
-  static const IconData? scan_sharp = IoniconsData(0xed55);
+  static const IconData scan_sharp = IoniconsData(0xed55);
 
   /// school
-  static const IconData? school = IoniconsData(0xed56);
+  static const IconData school = IoniconsData(0xed56);
 
   /// school-outline
-  static const IconData? school_outline = IoniconsData(0xed57);
+  static const IconData school_outline = IoniconsData(0xed57);
 
   /// school-sharp
-  static const IconData? school_sharp = IoniconsData(0xed58);
+  static const IconData school_sharp = IoniconsData(0xed58);
 
   /// search
-  static const IconData? search = IoniconsData(0xed59);
+  static const IconData search = IoniconsData(0xed59);
 
   /// search-circle
-  static const IconData? search_circle = IoniconsData(0xed5a);
+  static const IconData search_circle = IoniconsData(0xed5a);
 
   /// search-circle-outline
-  static const IconData? search_circle_outline = IoniconsData(0xed5b);
+  static const IconData search_circle_outline = IoniconsData(0xed5b);
 
   /// search-circle-sharp
-  static const IconData? search_circle_sharp = IoniconsData(0xed5c);
+  static const IconData search_circle_sharp = IoniconsData(0xed5c);
 
   /// search-outline
-  static const IconData? search_outline = IoniconsData(0xed5d);
+  static const IconData search_outline = IoniconsData(0xed5d);
 
   /// search-sharp
-  static const IconData? search_sharp = IoniconsData(0xed5e);
+  static const IconData search_sharp = IoniconsData(0xed5e);
 
   /// send
-  static const IconData? send = IoniconsData(0xed5f);
+  static const IconData send = IoniconsData(0xed5f);
 
   /// send-outline
-  static const IconData? send_outline = IoniconsData(0xed60);
+  static const IconData send_outline = IoniconsData(0xed60);
 
   /// send-sharp
-  static const IconData? send_sharp = IoniconsData(0xed61);
+  static const IconData send_sharp = IoniconsData(0xed61);
 
   /// server
-  static const IconData? server = IoniconsData(0xed62);
+  static const IconData server = IoniconsData(0xed62);
 
   /// server-outline
-  static const IconData? server_outline = IoniconsData(0xed63);
+  static const IconData server_outline = IoniconsData(0xed63);
 
   /// server-sharp
-  static const IconData? server_sharp = IoniconsData(0xed64);
+  static const IconData server_sharp = IoniconsData(0xed64);
 
   /// settings
-  static const IconData? settings = IoniconsData(0xed65);
+  static const IconData settings = IoniconsData(0xed65);
 
   /// settings-outline
-  static const IconData? settings_outline = IoniconsData(0xed66);
+  static const IconData settings_outline = IoniconsData(0xed66);
 
   /// settings-sharp
-  static const IconData? settings_sharp = IoniconsData(0xed67);
+  static const IconData settings_sharp = IoniconsData(0xed67);
 
   /// shapes
-  static const IconData? shapes = IoniconsData(0xed68);
+  static const IconData shapes = IoniconsData(0xed68);
 
   /// shapes-outline
-  static const IconData? shapes_outline = IoniconsData(0xed69);
+  static const IconData shapes_outline = IoniconsData(0xed69);
 
   /// shapes-sharp
-  static const IconData? shapes_sharp = IoniconsData(0xed6a);
+  static const IconData shapes_sharp = IoniconsData(0xed6a);
 
   /// share
-  static const IconData? share = IoniconsData(0xed6b);
+  static const IconData share = IoniconsData(0xed6b);
 
   /// share-outline
-  static const IconData? share_outline = IoniconsData(0xed6c);
+  static const IconData share_outline = IoniconsData(0xed6c);
 
   /// share-sharp
-  static const IconData? share_sharp = IoniconsData(0xed6d);
+  static const IconData share_sharp = IoniconsData(0xed6d);
 
   /// share-social
-  static const IconData? share_social = IoniconsData(0xed6e);
+  static const IconData share_social = IoniconsData(0xed6e);
 
   /// share-social-outline
-  static const IconData? share_social_outline = IoniconsData(0xed6f);
+  static const IconData share_social_outline = IoniconsData(0xed6f);
 
   /// share-social-sharp
-  static const IconData? share_social_sharp = IoniconsData(0xed70);
+  static const IconData share_social_sharp = IoniconsData(0xed70);
 
   /// shield
-  static const IconData? shield = IoniconsData(0xed71);
+  static const IconData shield = IoniconsData(0xed71);
 
   /// shield-checkmark
-  static const IconData? shield_checkmark = IoniconsData(0xed72);
+  static const IconData shield_checkmark = IoniconsData(0xed72);
 
   /// shield-checkmark-outline
-  static const IconData? shield_checkmark_outline = IoniconsData(0xed73);
+  static const IconData shield_checkmark_outline = IoniconsData(0xed73);
 
   /// shield-checkmark-sharp
-  static const IconData? shield_checkmark_sharp = IoniconsData(0xed74);
+  static const IconData shield_checkmark_sharp = IoniconsData(0xed74);
 
   /// shield-half
-  static const IconData? shield_half = IoniconsData(0xed75);
+  static const IconData shield_half = IoniconsData(0xed75);
 
   /// shield-half-outline
-  static const IconData? shield_half_outline = IoniconsData(0xed76);
+  static const IconData shield_half_outline = IoniconsData(0xed76);
 
   /// shield-half-sharp
-  static const IconData? shield_half_sharp = IoniconsData(0xed77);
+  static const IconData shield_half_sharp = IoniconsData(0xed77);
 
   /// shield-outline
-  static const IconData? shield_outline = IoniconsData(0xed78);
+  static const IconData shield_outline = IoniconsData(0xed78);
 
   /// shield-sharp
-  static const IconData? shield_sharp = IoniconsData(0xed79);
+  static const IconData shield_sharp = IoniconsData(0xed79);
 
   /// shirt
-  static const IconData? shirt = IoniconsData(0xed7a);
+  static const IconData shirt = IoniconsData(0xed7a);
 
   /// shirt-outline
-  static const IconData? shirt_outline = IoniconsData(0xed7b);
+  static const IconData shirt_outline = IoniconsData(0xed7b);
 
   /// shirt-sharp
-  static const IconData? shirt_sharp = IoniconsData(0xed7c);
+  static const IconData shirt_sharp = IoniconsData(0xed7c);
 
   /// shuffle
-  static const IconData? shuffle = IoniconsData(0xed7d);
+  static const IconData shuffle = IoniconsData(0xed7d);
 
   /// shuffle-outline
-  static const IconData? shuffle_outline = IoniconsData(0xed7e);
+  static const IconData shuffle_outline = IoniconsData(0xed7e);
 
   /// shuffle-sharp
-  static const IconData? shuffle_sharp = IoniconsData(0xed7f);
+  static const IconData shuffle_sharp = IoniconsData(0xed7f);
 
   /// skull
-  static const IconData? skull = IoniconsData(0xed80);
+  static const IconData skull = IoniconsData(0xed80);
 
   /// skull-outline
-  static const IconData? skull_outline = IoniconsData(0xed81);
+  static const IconData skull_outline = IoniconsData(0xed81);
 
   /// skull-sharp
-  static const IconData? skull_sharp = IoniconsData(0xed82);
+  static const IconData skull_sharp = IoniconsData(0xed82);
 
   /// snow
-  static const IconData? snow = IoniconsData(0xed83);
+  static const IconData snow = IoniconsData(0xed83);
 
   /// snow-outline
-  static const IconData? snow_outline = IoniconsData(0xed84);
+  static const IconData snow_outline = IoniconsData(0xed84);
 
   /// snow-sharp
-  static const IconData? snow_sharp = IoniconsData(0xed85);
+  static const IconData snow_sharp = IoniconsData(0xed85);
 
   /// sparkles
-  static const IconData? sparkles = IoniconsData(0xed86);
+  static const IconData sparkles = IoniconsData(0xed86);
 
   /// sparkles-outline
-  static const IconData? sparkles_outline = IoniconsData(0xed87);
+  static const IconData sparkles_outline = IoniconsData(0xed87);
 
   /// sparkles-sharp
-  static const IconData? sparkles_sharp = IoniconsData(0xed88);
+  static const IconData sparkles_sharp = IoniconsData(0xed88);
 
   /// speedometer
-  static const IconData? speedometer = IoniconsData(0xed89);
+  static const IconData speedometer = IoniconsData(0xed89);
 
   /// speedometer-outline
-  static const IconData? speedometer_outline = IoniconsData(0xed8a);
+  static const IconData speedometer_outline = IoniconsData(0xed8a);
 
   /// speedometer-sharp
-  static const IconData? speedometer_sharp = IoniconsData(0xed8b);
+  static const IconData speedometer_sharp = IoniconsData(0xed8b);
 
   /// square
-  static const IconData? square = IoniconsData(0xed8c);
+  static const IconData square = IoniconsData(0xed8c);
 
   /// square-outline
-  static const IconData? square_outline = IoniconsData(0xed8d);
+  static const IconData square_outline = IoniconsData(0xed8d);
 
   /// square-sharp
-  static const IconData? square_sharp = IoniconsData(0xed8e);
+  static const IconData square_sharp = IoniconsData(0xed8e);
 
   /// star
-  static const IconData? star = IoniconsData(0xed8f);
+  static const IconData star = IoniconsData(0xed8f);
 
   /// star-half
-  static const IconData? star_half = IoniconsData(0xed90);
+  static const IconData star_half = IoniconsData(0xed90);
 
   /// star-half-outline
-  static const IconData? star_half_outline = IoniconsData(0xed91);
+  static const IconData star_half_outline = IoniconsData(0xed91);
 
   /// star-half-sharp
-  static const IconData? star_half_sharp = IoniconsData(0xed92);
+  static const IconData star_half_sharp = IoniconsData(0xed92);
 
   /// star-outline
-  static const IconData? star_outline = IoniconsData(0xed93);
+  static const IconData star_outline = IoniconsData(0xed93);
 
   /// star-sharp
-  static const IconData? star_sharp = IoniconsData(0xed94);
+  static const IconData star_sharp = IoniconsData(0xed94);
 
   /// stats-chart
-  static const IconData? stats_chart = IoniconsData(0xed95);
+  static const IconData stats_chart = IoniconsData(0xed95);
 
   /// stats-chart-outline
-  static const IconData? stats_chart_outline = IoniconsData(0xed96);
+  static const IconData stats_chart_outline = IoniconsData(0xed96);
 
   /// stats-chart-sharp
-  static const IconData? stats_chart_sharp = IoniconsData(0xed97);
+  static const IconData stats_chart_sharp = IoniconsData(0xed97);
 
   /// stop
-  static const IconData? stop = IoniconsData(0xed98);
+  static const IconData stop = IoniconsData(0xed98);
 
   /// stop-circle
-  static const IconData? stop_circle = IoniconsData(0xed99);
+  static const IconData stop_circle = IoniconsData(0xed99);
 
   /// stop-circle-outline
-  static const IconData? stop_circle_outline = IoniconsData(0xed9a);
+  static const IconData stop_circle_outline = IoniconsData(0xed9a);
 
   /// stop-circle-sharp
-  static const IconData? stop_circle_sharp = IoniconsData(0xed9b);
+  static const IconData stop_circle_sharp = IoniconsData(0xed9b);
 
   /// stop-outline
-  static const IconData? stop_outline = IoniconsData(0xed9c);
+  static const IconData stop_outline = IoniconsData(0xed9c);
 
   /// stop-sharp
-  static const IconData? stop_sharp = IoniconsData(0xed9d);
+  static const IconData stop_sharp = IoniconsData(0xed9d);
 
   /// stopwatch
-  static const IconData? stopwatch = IoniconsData(0xed9e);
+  static const IconData stopwatch = IoniconsData(0xed9e);
 
   /// stopwatch-outline
-  static const IconData? stopwatch_outline = IoniconsData(0xed9f);
+  static const IconData stopwatch_outline = IoniconsData(0xed9f);
 
   /// stopwatch-sharp
-  static const IconData? stopwatch_sharp = IoniconsData(0xeda0);
+  static const IconData stopwatch_sharp = IoniconsData(0xeda0);
 
   /// storefront
-  static const IconData? storefront = IoniconsData(0xeda1);
+  static const IconData storefront = IoniconsData(0xeda1);
 
   /// storefront-outline
-  static const IconData? storefront_outline = IoniconsData(0xeda2);
+  static const IconData storefront_outline = IoniconsData(0xeda2);
 
   /// storefront-sharp
-  static const IconData? storefront_sharp = IoniconsData(0xeda3);
+  static const IconData storefront_sharp = IoniconsData(0xeda3);
 
   /// subway
-  static const IconData? subway = IoniconsData(0xeda4);
+  static const IconData subway = IoniconsData(0xeda4);
 
   /// subway-outline
-  static const IconData? subway_outline = IoniconsData(0xeda5);
+  static const IconData subway_outline = IoniconsData(0xeda5);
 
   /// subway-sharp
-  static const IconData? subway_sharp = IoniconsData(0xeda6);
+  static const IconData subway_sharp = IoniconsData(0xeda6);
 
   /// sunny
-  static const IconData? sunny = IoniconsData(0xeda7);
+  static const IconData sunny = IoniconsData(0xeda7);
 
   /// sunny-outline
-  static const IconData? sunny_outline = IoniconsData(0xeda8);
+  static const IconData sunny_outline = IoniconsData(0xeda8);
 
   /// sunny-sharp
-  static const IconData? sunny_sharp = IoniconsData(0xeda9);
+  static const IconData sunny_sharp = IoniconsData(0xeda9);
 
   /// swap-horizontal
-  static const IconData? swap_horizontal = IoniconsData(0xedaa);
+  static const IconData swap_horizontal = IoniconsData(0xedaa);
 
   /// swap-horizontal-outline
-  static const IconData? swap_horizontal_outline = IoniconsData(0xedab);
+  static const IconData swap_horizontal_outline = IoniconsData(0xedab);
 
   /// swap-horizontal-sharp
-  static const IconData? swap_horizontal_sharp = IoniconsData(0xedac);
+  static const IconData swap_horizontal_sharp = IoniconsData(0xedac);
 
   /// swap-vertical
-  static const IconData? swap_vertical = IoniconsData(0xedad);
+  static const IconData swap_vertical = IoniconsData(0xedad);
 
   /// swap-vertical-outline
-  static const IconData? swap_vertical_outline = IoniconsData(0xedae);
+  static const IconData swap_vertical_outline = IoniconsData(0xedae);
 
   /// swap-vertical-sharp
-  static const IconData? swap_vertical_sharp = IoniconsData(0xedaf);
+  static const IconData swap_vertical_sharp = IoniconsData(0xedaf);
 
   /// sync
-  static const IconData? sync = IoniconsData(0xedb0);
+  static const IconData sync = IoniconsData(0xedb0);
 
   /// sync-circle
-  static const IconData? sync_circle = IoniconsData(0xedb1);
+  static const IconData sync_circle = IoniconsData(0xedb1);
 
   /// sync-circle-outline
-  static const IconData? sync_circle_outline = IoniconsData(0xedb2);
+  static const IconData sync_circle_outline = IoniconsData(0xedb2);
 
   /// sync-circle-sharp
-  static const IconData? sync_circle_sharp = IoniconsData(0xedb3);
+  static const IconData sync_circle_sharp = IoniconsData(0xedb3);
 
   /// sync-outline
-  static const IconData? sync_outline = IoniconsData(0xedb4);
+  static const IconData sync_outline = IoniconsData(0xedb4);
 
   /// sync-sharp
-  static const IconData? sync_sharp = IoniconsData(0xedb5);
+  static const IconData sync_sharp = IoniconsData(0xedb5);
 
   /// tablet-landscape
-  static const IconData? tablet_landscape = IoniconsData(0xedb6);
+  static const IconData tablet_landscape = IoniconsData(0xedb6);
 
   /// tablet-landscape-outline
-  static const IconData? tablet_landscape_outline = IoniconsData(0xedb7);
+  static const IconData tablet_landscape_outline = IoniconsData(0xedb7);
 
   /// tablet-landscape-sharp
-  static const IconData? tablet_landscape_sharp = IoniconsData(0xedb8);
+  static const IconData tablet_landscape_sharp = IoniconsData(0xedb8);
 
   /// tablet-portrait
-  static const IconData? tablet_portrait = IoniconsData(0xedb9);
+  static const IconData tablet_portrait = IoniconsData(0xedb9);
 
   /// tablet-portrait-outline
-  static const IconData? tablet_portrait_outline = IoniconsData(0xedba);
+  static const IconData tablet_portrait_outline = IoniconsData(0xedba);
 
   /// tablet-portrait-sharp
-  static const IconData? tablet_portrait_sharp = IoniconsData(0xedbb);
+  static const IconData tablet_portrait_sharp = IoniconsData(0xedbb);
 
   /// telescope
-  static const IconData? telescope = IoniconsData(0xedbc);
+  static const IconData telescope = IoniconsData(0xedbc);
 
   /// telescope-outline
-  static const IconData? telescope_outline = IoniconsData(0xedbd);
+  static const IconData telescope_outline = IoniconsData(0xedbd);
 
   /// telescope-sharp
-  static const IconData? telescope_sharp = IoniconsData(0xedbe);
+  static const IconData telescope_sharp = IoniconsData(0xedbe);
 
   /// tennisball
-  static const IconData? tennisball = IoniconsData(0xedbf);
+  static const IconData tennisball = IoniconsData(0xedbf);
 
   /// tennisball-outline
-  static const IconData? tennisball_outline = IoniconsData(0xedc0);
+  static const IconData tennisball_outline = IoniconsData(0xedc0);
 
   /// tennisball-sharp
-  static const IconData? tennisball_sharp = IoniconsData(0xedc1);
+  static const IconData tennisball_sharp = IoniconsData(0xedc1);
 
   /// terminal
-  static const IconData? terminal = IoniconsData(0xedc2);
+  static const IconData terminal = IoniconsData(0xedc2);
 
   /// terminal-outline
-  static const IconData? terminal_outline = IoniconsData(0xedc3);
+  static const IconData terminal_outline = IoniconsData(0xedc3);
 
   /// terminal-sharp
-  static const IconData? terminal_sharp = IoniconsData(0xedc4);
+  static const IconData terminal_sharp = IoniconsData(0xedc4);
 
   /// text
-  static const IconData? text = IoniconsData(0xedc5);
+  static const IconData text = IoniconsData(0xedc5);
 
   /// text-outline
-  static const IconData? text_outline = IoniconsData(0xedc6);
+  static const IconData text_outline = IoniconsData(0xedc6);
 
   /// text-sharp
-  static const IconData? text_sharp = IoniconsData(0xedc7);
+  static const IconData text_sharp = IoniconsData(0xedc7);
 
   /// thermometer
-  static const IconData? thermometer = IoniconsData(0xedc8);
+  static const IconData thermometer = IoniconsData(0xedc8);
 
   /// thermometer-outline
-  static const IconData? thermometer_outline = IoniconsData(0xedc9);
+  static const IconData thermometer_outline = IoniconsData(0xedc9);
 
   /// thermometer-sharp
-  static const IconData? thermometer_sharp = IoniconsData(0xedca);
+  static const IconData thermometer_sharp = IoniconsData(0xedca);
 
   /// thumbs-down
-  static const IconData? thumbs_down = IoniconsData(0xedcb);
+  static const IconData thumbs_down = IoniconsData(0xedcb);
 
   /// thumbs-down-outline
-  static const IconData? thumbs_down_outline = IoniconsData(0xedcc);
+  static const IconData thumbs_down_outline = IoniconsData(0xedcc);
 
   /// thumbs-down-sharp
-  static const IconData? thumbs_down_sharp = IoniconsData(0xedcd);
+  static const IconData thumbs_down_sharp = IoniconsData(0xedcd);
 
   /// thumbs-up
-  static const IconData? thumbs_up = IoniconsData(0xedce);
+  static const IconData thumbs_up = IoniconsData(0xedce);
 
   /// thumbs-up-outline
-  static const IconData? thumbs_up_outline = IoniconsData(0xedcf);
+  static const IconData thumbs_up_outline = IoniconsData(0xedcf);
 
   /// thumbs-up-sharp
-  static const IconData? thumbs_up_sharp = IoniconsData(0xedd0);
+  static const IconData thumbs_up_sharp = IoniconsData(0xedd0);
 
   /// thunderstorm
-  static const IconData? thunderstorm = IoniconsData(0xedd1);
+  static const IconData thunderstorm = IoniconsData(0xedd1);
 
   /// thunderstorm-outline
-  static const IconData? thunderstorm_outline = IoniconsData(0xedd2);
+  static const IconData thunderstorm_outline = IoniconsData(0xedd2);
 
   /// thunderstorm-sharp
-  static const IconData? thunderstorm_sharp = IoniconsData(0xedd3);
+  static const IconData thunderstorm_sharp = IoniconsData(0xedd3);
 
   /// ticket
-  static const IconData? ticket = IoniconsData(0xedd4);
+  static const IconData ticket = IoniconsData(0xedd4);
 
   /// ticket-outline
-  static const IconData? ticket_outline = IoniconsData(0xedd5);
+  static const IconData ticket_outline = IoniconsData(0xedd5);
 
   /// ticket-sharp
-  static const IconData? ticket_sharp = IoniconsData(0xedd6);
+  static const IconData ticket_sharp = IoniconsData(0xedd6);
 
   /// time
-  static const IconData? time = IoniconsData(0xedd7);
+  static const IconData time = IoniconsData(0xedd7);
 
   /// time-outline
-  static const IconData? time_outline = IoniconsData(0xedd8);
+  static const IconData time_outline = IoniconsData(0xedd8);
 
   /// timer
-  static const IconData? timer = IoniconsData(0xedd9);
+  static const IconData timer = IoniconsData(0xedd9);
 
   /// timer-outline
-  static const IconData? timer_outline = IoniconsData(0xedda);
+  static const IconData timer_outline = IoniconsData(0xedda);
 
   /// timer-sharp
-  static const IconData? timer_sharp = IoniconsData(0xeddb);
+  static const IconData timer_sharp = IoniconsData(0xeddb);
 
   /// time-sharp
-  static const IconData? time_sharp = IoniconsData(0xeddc);
+  static const IconData time_sharp = IoniconsData(0xeddc);
 
   /// today
-  static const IconData? today = IoniconsData(0xeddd);
+  static const IconData today = IoniconsData(0xeddd);
 
   /// today-outline
-  static const IconData? today_outline = IoniconsData(0xedde);
+  static const IconData today_outline = IoniconsData(0xedde);
 
   /// today-sharp
-  static const IconData? today_sharp = IoniconsData(0xeddf);
+  static const IconData today_sharp = IoniconsData(0xeddf);
 
   /// toggle
-  static const IconData? toggle = IoniconsData(0xede0);
+  static const IconData toggle = IoniconsData(0xede0);
 
   /// toggle-outline
-  static const IconData? toggle_outline = IoniconsData(0xede1);
+  static const IconData toggle_outline = IoniconsData(0xede1);
 
   /// toggle-sharp
-  static const IconData? toggle_sharp = IoniconsData(0xede2);
+  static const IconData toggle_sharp = IoniconsData(0xede2);
 
   /// trail-sign
-  static const IconData? trail_sign = IoniconsData(0xede3);
+  static const IconData trail_sign = IoniconsData(0xede3);
 
   /// trail-sign-outline
-  static const IconData? trail_sign_outline = IoniconsData(0xede4);
+  static const IconData trail_sign_outline = IoniconsData(0xede4);
 
   /// trail-sign-sharp
-  static const IconData? trail_sign_sharp = IoniconsData(0xede5);
+  static const IconData trail_sign_sharp = IoniconsData(0xede5);
 
   /// train
-  static const IconData? train = IoniconsData(0xede6);
+  static const IconData train = IoniconsData(0xede6);
 
   /// train-outline
-  static const IconData? train_outline = IoniconsData(0xede7);
+  static const IconData train_outline = IoniconsData(0xede7);
 
   /// train-sharp
-  static const IconData? train_sharp = IoniconsData(0xede8);
+  static const IconData train_sharp = IoniconsData(0xede8);
 
   /// transgender
-  static const IconData? transgender = IoniconsData(0xede9);
+  static const IconData transgender = IoniconsData(0xede9);
 
   /// transgender-outline
-  static const IconData? transgender_outline = IoniconsData(0xedea);
+  static const IconData transgender_outline = IoniconsData(0xedea);
 
   /// transgender-sharp
-  static const IconData? transgender_sharp = IoniconsData(0xedeb);
+  static const IconData transgender_sharp = IoniconsData(0xedeb);
 
   /// trash
-  static const IconData? trash = IoniconsData(0xedec);
+  static const IconData trash = IoniconsData(0xedec);
 
   /// trash-bin
-  static const IconData? trash_bin = IoniconsData(0xeded);
+  static const IconData trash_bin = IoniconsData(0xeded);
 
   /// trash-bin-outline
-  static const IconData? trash_bin_outline = IoniconsData(0xedee);
+  static const IconData trash_bin_outline = IoniconsData(0xedee);
 
   /// trash-bin-sharp
-  static const IconData? trash_bin_sharp = IoniconsData(0xedef);
+  static const IconData trash_bin_sharp = IoniconsData(0xedef);
 
   /// trash-outline
-  static const IconData? trash_outline = IoniconsData(0xedf0);
+  static const IconData trash_outline = IoniconsData(0xedf0);
 
   /// trash-sharp
-  static const IconData? trash_sharp = IoniconsData(0xedf1);
+  static const IconData trash_sharp = IoniconsData(0xedf1);
 
   /// trending-down
-  static const IconData? trending_down = IoniconsData(0xedf2);
+  static const IconData trending_down = IoniconsData(0xedf2);
 
   /// trending-down-outline
-  static const IconData? trending_down_outline = IoniconsData(0xedf3);
+  static const IconData trending_down_outline = IoniconsData(0xedf3);
 
   /// trending-down-sharp
-  static const IconData? trending_down_sharp = IoniconsData(0xedf4);
+  static const IconData trending_down_sharp = IoniconsData(0xedf4);
 
   /// trending-up
-  static const IconData? trending_up = IoniconsData(0xedf5);
+  static const IconData trending_up = IoniconsData(0xedf5);
 
   /// trending-up-outline
-  static const IconData? trending_up_outline = IoniconsData(0xedf6);
+  static const IconData trending_up_outline = IoniconsData(0xedf6);
 
   /// trending-up-sharp
-  static const IconData? trending_up_sharp = IoniconsData(0xedf7);
+  static const IconData trending_up_sharp = IoniconsData(0xedf7);
 
   /// triangle
-  static const IconData? triangle = IoniconsData(0xedf8);
+  static const IconData triangle = IoniconsData(0xedf8);
 
   /// triangle-outline
-  static const IconData? triangle_outline = IoniconsData(0xedf9);
+  static const IconData triangle_outline = IoniconsData(0xedf9);
 
   /// triangle-sharp
-  static const IconData? triangle_sharp = IoniconsData(0xedfa);
+  static const IconData triangle_sharp = IoniconsData(0xedfa);
 
   /// trophy
-  static const IconData? trophy = IoniconsData(0xedfb);
+  static const IconData trophy = IoniconsData(0xedfb);
 
   /// trophy-outline
-  static const IconData? trophy_outline = IoniconsData(0xedfc);
+  static const IconData trophy_outline = IoniconsData(0xedfc);
 
   /// trophy-sharp
-  static const IconData? trophy_sharp = IoniconsData(0xedfd);
+  static const IconData trophy_sharp = IoniconsData(0xedfd);
 
   /// tv
-  static const IconData? tv = IoniconsData(0xedfe);
+  static const IconData tv = IoniconsData(0xedfe);
 
   /// tv-outline
-  static const IconData? tv_outline = IoniconsData(0xedff);
+  static const IconData tv_outline = IoniconsData(0xedff);
 
   /// tv-sharp
-  static const IconData? tv_sharp = IoniconsData(0xee00);
+  static const IconData tv_sharp = IoniconsData(0xee00);
 
   /// umbrella
-  static const IconData? umbrella = IoniconsData(0xee01);
+  static const IconData umbrella = IoniconsData(0xee01);
 
   /// umbrella-outline
-  static const IconData? umbrella_outline = IoniconsData(0xee02);
+  static const IconData umbrella_outline = IoniconsData(0xee02);
 
   /// umbrella-sharp
-  static const IconData? umbrella_sharp = IoniconsData(0xee03);
+  static const IconData umbrella_sharp = IoniconsData(0xee03);
 
   /// unlink
-  static const IconData? unlink = IoniconsData(0xee04);
+  static const IconData unlink = IoniconsData(0xee04);
 
   /// unlink-outline
-  static const IconData? unlink_outline = IoniconsData(0xee05);
+  static const IconData unlink_outline = IoniconsData(0xee05);
 
   /// unlink-sharp
-  static const IconData? unlink_sharp = IoniconsData(0xee06);
+  static const IconData unlink_sharp = IoniconsData(0xee06);
 
   /// videocam
-  static const IconData? videocam = IoniconsData(0xee07);
+  static const IconData videocam = IoniconsData(0xee07);
 
   /// videocam-off
-  static const IconData? videocam_off = IoniconsData(0xee08);
+  static const IconData videocam_off = IoniconsData(0xee08);
 
   /// videocam-off-outline
-  static const IconData? videocam_off_outline = IoniconsData(0xee09);
+  static const IconData videocam_off_outline = IoniconsData(0xee09);
 
   /// videocam-off-sharp
-  static const IconData? videocam_off_sharp = IoniconsData(0xee0a);
+  static const IconData videocam_off_sharp = IoniconsData(0xee0a);
 
   /// videocam-outline
-  static const IconData? videocam_outline = IoniconsData(0xee0b);
+  static const IconData videocam_outline = IoniconsData(0xee0b);
 
   /// videocam-sharp
-  static const IconData? videocam_sharp = IoniconsData(0xee0c);
+  static const IconData videocam_sharp = IoniconsData(0xee0c);
 
   /// volume-high
-  static const IconData? volume_high = IoniconsData(0xee0d);
+  static const IconData volume_high = IoniconsData(0xee0d);
 
   /// volume-high-outline
-  static const IconData? volume_high_outline = IoniconsData(0xee0e);
+  static const IconData volume_high_outline = IoniconsData(0xee0e);
 
   /// volume-high-sharp
-  static const IconData? volume_high_sharp = IoniconsData(0xee0f);
+  static const IconData volume_high_sharp = IoniconsData(0xee0f);
 
   /// volume-low
-  static const IconData? volume_low = IoniconsData(0xee10);
+  static const IconData volume_low = IoniconsData(0xee10);
 
   /// volume-low-outline
-  static const IconData? volume_low_outline = IoniconsData(0xee11);
+  static const IconData volume_low_outline = IoniconsData(0xee11);
 
   /// volume-low-sharp
-  static const IconData? volume_low_sharp = IoniconsData(0xee12);
+  static const IconData volume_low_sharp = IoniconsData(0xee12);
 
   /// volume-medium
-  static const IconData? volume_medium = IoniconsData(0xee13);
+  static const IconData volume_medium = IoniconsData(0xee13);
 
   /// volume-medium-outline
-  static const IconData? volume_medium_outline = IoniconsData(0xee14);
+  static const IconData volume_medium_outline = IoniconsData(0xee14);
 
   /// volume-medium-sharp
-  static const IconData? volume_medium_sharp = IoniconsData(0xee15);
+  static const IconData volume_medium_sharp = IoniconsData(0xee15);
 
   /// volume-mute
-  static const IconData? volume_mute = IoniconsData(0xee16);
+  static const IconData volume_mute = IoniconsData(0xee16);
 
   /// volume-mute-outline
-  static const IconData? volume_mute_outline = IoniconsData(0xee17);
+  static const IconData volume_mute_outline = IoniconsData(0xee17);
 
   /// volume-mute-sharp
-  static const IconData? volume_mute_sharp = IoniconsData(0xee18);
+  static const IconData volume_mute_sharp = IoniconsData(0xee18);
 
   /// volume-off
-  static const IconData? volume_off = IoniconsData(0xee19);
+  static const IconData volume_off = IoniconsData(0xee19);
 
   /// volume-off-outline
-  static const IconData? volume_off_outline = IoniconsData(0xee1a);
+  static const IconData volume_off_outline = IoniconsData(0xee1a);
 
   /// volume-off-sharp
-  static const IconData? volume_off_sharp = IoniconsData(0xee1b);
+  static const IconData volume_off_sharp = IoniconsData(0xee1b);
 
   /// walk
-  static const IconData? walk = IoniconsData(0xee1c);
+  static const IconData walk = IoniconsData(0xee1c);
 
   /// walk-outline
-  static const IconData? walk_outline = IoniconsData(0xee1d);
+  static const IconData walk_outline = IoniconsData(0xee1d);
 
   /// walk-sharp
-  static const IconData? walk_sharp = IoniconsData(0xee1e);
+  static const IconData walk_sharp = IoniconsData(0xee1e);
 
   /// wallet
-  static const IconData? wallet = IoniconsData(0xee1f);
+  static const IconData wallet = IoniconsData(0xee1f);
 
   /// wallet-outline
-  static const IconData? wallet_outline = IoniconsData(0xee20);
+  static const IconData wallet_outline = IoniconsData(0xee20);
 
   /// wallet-sharp
-  static const IconData? wallet_sharp = IoniconsData(0xee21);
+  static const IconData wallet_sharp = IoniconsData(0xee21);
 
   /// warning
-  static const IconData? warning = IoniconsData(0xee22);
+  static const IconData warning = IoniconsData(0xee22);
 
   /// warning-outline
-  static const IconData? warning_outline = IoniconsData(0xee23);
+  static const IconData warning_outline = IoniconsData(0xee23);
 
   /// warning-sharp
-  static const IconData? warning_sharp = IoniconsData(0xee24);
+  static const IconData warning_sharp = IoniconsData(0xee24);
 
   /// watch
-  static const IconData? watch = IoniconsData(0xee25);
+  static const IconData watch = IoniconsData(0xee25);
 
   /// watch-outline
-  static const IconData? watch_outline = IoniconsData(0xee26);
+  static const IconData watch_outline = IoniconsData(0xee26);
 
   /// watch-sharp
-  static const IconData? watch_sharp = IoniconsData(0xee27);
+  static const IconData watch_sharp = IoniconsData(0xee27);
 
   /// water
-  static const IconData? water = IoniconsData(0xee28);
+  static const IconData water = IoniconsData(0xee28);
 
   /// water-outline
-  static const IconData? water_outline = IoniconsData(0xee29);
+  static const IconData water_outline = IoniconsData(0xee29);
 
   /// water-sharp
-  static const IconData? water_sharp = IoniconsData(0xee2a);
+  static const IconData water_sharp = IoniconsData(0xee2a);
 
   /// wifi
-  static const IconData? wifi = IoniconsData(0xee2b);
+  static const IconData wifi = IoniconsData(0xee2b);
 
   /// wifi-outline
-  static const IconData? wifi_outline = IoniconsData(0xee2c);
+  static const IconData wifi_outline = IoniconsData(0xee2c);
 
   /// wifi-sharp
-  static const IconData? wifi_sharp = IoniconsData(0xee2d);
+  static const IconData wifi_sharp = IoniconsData(0xee2d);
 
   /// wine
-  static const IconData? wine = IoniconsData(0xee2e);
+  static const IconData wine = IoniconsData(0xee2e);
 
   /// wine-outline
-  static const IconData? wine_outline = IoniconsData(0xee2f);
+  static const IconData wine_outline = IoniconsData(0xee2f);
 
   /// wine-sharp
-  static const IconData? wine_sharp = IoniconsData(0xee30);
+  static const IconData wine_sharp = IoniconsData(0xee30);
 
   /// woman
-  static const IconData? woman = IoniconsData(0xee31);
+  static const IconData woman = IoniconsData(0xee31);
 
   /// woman-outline
-  static const IconData? woman_outline = IoniconsData(0xee32);
+  static const IconData woman_outline = IoniconsData(0xee32);
 
   /// woman-sharp
-  static const IconData? woman_sharp = IoniconsData(0xee33);
+  static const IconData woman_sharp = IoniconsData(0xee33);
 }

--- a/lib/ionicons.dart
+++ b/lib/ionicons.dart
@@ -14,3999 +14,3999 @@ class IoniconsData extends IconData {
 /// Ionicons data, see https://ionicons.com/ for more info
 class Ionicons {
   /// accessibility
-  static const IconData accessibility = IoniconsData(0xe900);
+  static const IconData? accessibility = IoniconsData(0xe900);
 
   /// accessibility-outline
-  static const IconData accessibility_outline = IoniconsData(0xe901);
+  static const IconData? accessibility_outline = IoniconsData(0xe901);
 
   /// accessibility-sharp
-  static const IconData accessibility_sharp = IoniconsData(0xe902);
+  static const IconData? accessibility_sharp = IoniconsData(0xe902);
 
   /// add
-  static const IconData add = IoniconsData(0xe903);
+  static const IconData? add = IoniconsData(0xe903);
 
   /// add-circle
-  static const IconData add_circle = IoniconsData(0xe904);
+  static const IconData? add_circle = IoniconsData(0xe904);
 
   /// add-circle-outline
-  static const IconData add_circle_outline = IoniconsData(0xe905);
+  static const IconData? add_circle_outline = IoniconsData(0xe905);
 
   /// add-circle-sharp
-  static const IconData add_circle_sharp = IoniconsData(0xe906);
+  static const IconData? add_circle_sharp = IoniconsData(0xe906);
 
   /// add-outline
-  static const IconData add_outline = IoniconsData(0xe907);
+  static const IconData? add_outline = IoniconsData(0xe907);
 
   /// add-sharp
-  static const IconData add_sharp = IoniconsData(0xe908);
+  static const IconData? add_sharp = IoniconsData(0xe908);
 
   /// airplane
-  static const IconData airplane = IoniconsData(0xe909);
+  static const IconData? airplane = IoniconsData(0xe909);
 
   /// airplane-outline
-  static const IconData airplane_outline = IoniconsData(0xe90a);
+  static const IconData? airplane_outline = IoniconsData(0xe90a);
 
   /// airplane-sharp
-  static const IconData airplane_sharp = IoniconsData(0xe90b);
+  static const IconData? airplane_sharp = IoniconsData(0xe90b);
 
   /// alarm
-  static const IconData alarm = IoniconsData(0xe90c);
+  static const IconData? alarm = IoniconsData(0xe90c);
 
   /// alarm-outline
-  static const IconData alarm_outline = IoniconsData(0xe90d);
+  static const IconData? alarm_outline = IoniconsData(0xe90d);
 
   /// alarm-sharp
-  static const IconData alarm_sharp = IoniconsData(0xe90e);
+  static const IconData? alarm_sharp = IoniconsData(0xe90e);
 
   /// albums
-  static const IconData albums = IoniconsData(0xe90f);
+  static const IconData? albums = IoniconsData(0xe90f);
 
   /// albums-outline
-  static const IconData albums_outline = IoniconsData(0xe910);
+  static const IconData? albums_outline = IoniconsData(0xe910);
 
   /// albums-sharp
-  static const IconData albums_sharp = IoniconsData(0xe911);
+  static const IconData? albums_sharp = IoniconsData(0xe911);
 
   /// alert
-  static const IconData alert = IoniconsData(0xe912);
+  static const IconData? alert = IoniconsData(0xe912);
 
   /// alert-circle
-  static const IconData alert_circle = IoniconsData(0xe913);
+  static const IconData? alert_circle = IoniconsData(0xe913);
 
   /// alert-circle-outline
-  static const IconData alert_circle_outline = IoniconsData(0xe914);
+  static const IconData? alert_circle_outline = IoniconsData(0xe914);
 
   /// alert-circle-sharp
-  static const IconData alert_circle_sharp = IoniconsData(0xe915);
+  static const IconData? alert_circle_sharp = IoniconsData(0xe915);
 
   /// alert-outline
-  static const IconData alert_outline = IoniconsData(0xe916);
+  static const IconData? alert_outline = IoniconsData(0xe916);
 
   /// alert-sharp
-  static const IconData alert_sharp = IoniconsData(0xe917);
+  static const IconData? alert_sharp = IoniconsData(0xe917);
 
   /// american-football
-  static const IconData american_football = IoniconsData(0xe918);
+  static const IconData? american_football = IoniconsData(0xe918);
 
   /// american-football-outline
-  static const IconData american_football_outline = IoniconsData(0xe919);
+  static const IconData? american_football_outline = IoniconsData(0xe919);
 
   /// american-football-sharp
-  static const IconData american_football_sharp = IoniconsData(0xe91a);
+  static const IconData? american_football_sharp = IoniconsData(0xe91a);
 
   /// analytics
-  static const IconData analytics = IoniconsData(0xe91b);
+  static const IconData? analytics = IoniconsData(0xe91b);
 
   /// analytics-outline
-  static const IconData analytics_outline = IoniconsData(0xe91c);
+  static const IconData? analytics_outline = IoniconsData(0xe91c);
 
   /// analytics-sharp
-  static const IconData analytics_sharp = IoniconsData(0xe91d);
+  static const IconData? analytics_sharp = IoniconsData(0xe91d);
 
   /// aperture
-  static const IconData aperture = IoniconsData(0xe91e);
+  static const IconData? aperture = IoniconsData(0xe91e);
 
   /// aperture-outline
-  static const IconData aperture_outline = IoniconsData(0xe91f);
+  static const IconData? aperture_outline = IoniconsData(0xe91f);
 
   /// aperture-sharp
-  static const IconData aperture_sharp = IoniconsData(0xe920);
+  static const IconData? aperture_sharp = IoniconsData(0xe920);
 
   /// apps
-  static const IconData apps = IoniconsData(0xe921);
+  static const IconData? apps = IoniconsData(0xe921);
 
   /// apps-outline
-  static const IconData apps_outline = IoniconsData(0xe922);
+  static const IconData? apps_outline = IoniconsData(0xe922);
 
   /// apps-sharp
-  static const IconData apps_sharp = IoniconsData(0xe923);
+  static const IconData? apps_sharp = IoniconsData(0xe923);
 
   /// archive
-  static const IconData archive = IoniconsData(0xe924);
+  static const IconData? archive = IoniconsData(0xe924);
 
   /// archive-outline
-  static const IconData archive_outline = IoniconsData(0xe925);
+  static const IconData? archive_outline = IoniconsData(0xe925);
 
   /// archive-sharp
-  static const IconData archive_sharp = IoniconsData(0xe926);
+  static const IconData? archive_sharp = IoniconsData(0xe926);
 
   /// arrow-back
-  static const IconData arrow_back = IoniconsData(0xe927);
+  static const IconData? arrow_back = IoniconsData(0xe927);
 
   /// arrow-back-circle
-  static const IconData arrow_back_circle = IoniconsData(0xe928);
+  static const IconData? arrow_back_circle = IoniconsData(0xe928);
 
   /// arrow-back-circle-outline
-  static const IconData arrow_back_circle_outline = IoniconsData(0xe929);
+  static const IconData? arrow_back_circle_outline = IoniconsData(0xe929);
 
   /// arrow-back-circle-sharp
-  static const IconData arrow_back_circle_sharp = IoniconsData(0xe92a);
+  static const IconData? arrow_back_circle_sharp = IoniconsData(0xe92a);
 
   /// arrow-back-outline
-  static const IconData arrow_back_outline = IoniconsData(0xe92b);
+  static const IconData? arrow_back_outline = IoniconsData(0xe92b);
 
   /// arrow-back-sharp
-  static const IconData arrow_back_sharp = IoniconsData(0xe92c);
+  static const IconData? arrow_back_sharp = IoniconsData(0xe92c);
 
   /// arrow-down
-  static const IconData arrow_down = IoniconsData(0xe92d);
+  static const IconData? arrow_down = IoniconsData(0xe92d);
 
   /// arrow-down-circle
-  static const IconData arrow_down_circle = IoniconsData(0xe92e);
+  static const IconData? arrow_down_circle = IoniconsData(0xe92e);
 
   /// arrow-down-circle-outline
-  static const IconData arrow_down_circle_outline = IoniconsData(0xe92f);
+  static const IconData? arrow_down_circle_outline = IoniconsData(0xe92f);
 
   /// arrow-down-circle-sharp
-  static const IconData arrow_down_circle_sharp = IoniconsData(0xe930);
+  static const IconData? arrow_down_circle_sharp = IoniconsData(0xe930);
 
   /// arrow-down-outline
-  static const IconData arrow_down_outline = IoniconsData(0xe931);
+  static const IconData? arrow_down_outline = IoniconsData(0xe931);
 
   /// arrow-down-sharp
-  static const IconData arrow_down_sharp = IoniconsData(0xe932);
+  static const IconData? arrow_down_sharp = IoniconsData(0xe932);
 
   /// arrow-forward
-  static const IconData arrow_forward = IoniconsData(0xe933);
+  static const IconData? arrow_forward = IoniconsData(0xe933);
 
   /// arrow-forward-circle
-  static const IconData arrow_forward_circle = IoniconsData(0xe934);
+  static const IconData? arrow_forward_circle = IoniconsData(0xe934);
 
   /// arrow-forward-circle-outline
-  static const IconData arrow_forward_circle_outline = IoniconsData(0xe935);
+  static const IconData? arrow_forward_circle_outline = IoniconsData(0xe935);
 
   /// arrow-forward-circle-sharp
-  static const IconData arrow_forward_circle_sharp = IoniconsData(0xe936);
+  static const IconData? arrow_forward_circle_sharp = IoniconsData(0xe936);
 
   /// arrow-forward-outline
-  static const IconData arrow_forward_outline = IoniconsData(0xe937);
+  static const IconData? arrow_forward_outline = IoniconsData(0xe937);
 
   /// arrow-forward-sharp
-  static const IconData arrow_forward_sharp = IoniconsData(0xe938);
+  static const IconData? arrow_forward_sharp = IoniconsData(0xe938);
 
   /// arrow-redo
-  static const IconData arrow_redo = IoniconsData(0xe939);
+  static const IconData? arrow_redo = IoniconsData(0xe939);
 
   /// arrow-redo-circle
-  static const IconData arrow_redo_circle = IoniconsData(0xe93a);
+  static const IconData? arrow_redo_circle = IoniconsData(0xe93a);
 
   /// arrow-redo-circle-outline
-  static const IconData arrow_redo_circle_outline = IoniconsData(0xe93b);
+  static const IconData? arrow_redo_circle_outline = IoniconsData(0xe93b);
 
   /// arrow-redo-circle-sharp
-  static const IconData arrow_redo_circle_sharp = IoniconsData(0xe93c);
+  static const IconData? arrow_redo_circle_sharp = IoniconsData(0xe93c);
 
   /// arrow-redo-outline
-  static const IconData arrow_redo_outline = IoniconsData(0xe93d);
+  static const IconData? arrow_redo_outline = IoniconsData(0xe93d);
 
   /// arrow-redo-sharp
-  static const IconData arrow_redo_sharp = IoniconsData(0xe93e);
+  static const IconData? arrow_redo_sharp = IoniconsData(0xe93e);
 
   /// arrow-undo
-  static const IconData arrow_undo = IoniconsData(0xe93f);
+  static const IconData? arrow_undo = IoniconsData(0xe93f);
 
   /// arrow-undo-circle
-  static const IconData arrow_undo_circle = IoniconsData(0xe940);
+  static const IconData? arrow_undo_circle = IoniconsData(0xe940);
 
   /// arrow-undo-circle-outline
-  static const IconData arrow_undo_circle_outline = IoniconsData(0xe941);
+  static const IconData? arrow_undo_circle_outline = IoniconsData(0xe941);
 
   /// arrow-undo-circle-sharp
-  static const IconData arrow_undo_circle_sharp = IoniconsData(0xe942);
+  static const IconData? arrow_undo_circle_sharp = IoniconsData(0xe942);
 
   /// arrow-undo-outline
-  static const IconData arrow_undo_outline = IoniconsData(0xe943);
+  static const IconData? arrow_undo_outline = IoniconsData(0xe943);
 
   /// arrow-undo-sharp
-  static const IconData arrow_undo_sharp = IoniconsData(0xe944);
+  static const IconData? arrow_undo_sharp = IoniconsData(0xe944);
 
   /// arrow-up
-  static const IconData arrow_up = IoniconsData(0xe945);
+  static const IconData? arrow_up = IoniconsData(0xe945);
 
   /// arrow-up-circle
-  static const IconData arrow_up_circle = IoniconsData(0xe946);
+  static const IconData? arrow_up_circle = IoniconsData(0xe946);
 
   /// arrow-up-circle-outline
-  static const IconData arrow_up_circle_outline = IoniconsData(0xe947);
+  static const IconData? arrow_up_circle_outline = IoniconsData(0xe947);
 
   /// arrow-up-circle-sharp
-  static const IconData arrow_up_circle_sharp = IoniconsData(0xe948);
+  static const IconData? arrow_up_circle_sharp = IoniconsData(0xe948);
 
   /// arrow-up-outline
-  static const IconData arrow_up_outline = IoniconsData(0xe949);
+  static const IconData? arrow_up_outline = IoniconsData(0xe949);
 
   /// arrow-up-sharp
-  static const IconData arrow_up_sharp = IoniconsData(0xe94a);
+  static const IconData? arrow_up_sharp = IoniconsData(0xe94a);
 
   /// at
-  static const IconData at = IoniconsData(0xe94b);
+  static const IconData? at = IoniconsData(0xe94b);
 
   /// at-circle
-  static const IconData at_circle = IoniconsData(0xe94c);
+  static const IconData? at_circle = IoniconsData(0xe94c);
 
   /// at-circle-outline
-  static const IconData at_circle_outline = IoniconsData(0xe94d);
+  static const IconData? at_circle_outline = IoniconsData(0xe94d);
 
   /// at-circle-sharp
-  static const IconData at_circle_sharp = IoniconsData(0xe94e);
+  static const IconData? at_circle_sharp = IoniconsData(0xe94e);
 
   /// at-outline
-  static const IconData at_outline = IoniconsData(0xe94f);
+  static const IconData? at_outline = IoniconsData(0xe94f);
 
   /// at-sharp
-  static const IconData at_sharp = IoniconsData(0xe950);
+  static const IconData? at_sharp = IoniconsData(0xe950);
 
   /// attach
-  static const IconData attach = IoniconsData(0xe951);
+  static const IconData? attach = IoniconsData(0xe951);
 
   /// attach-outline
-  static const IconData attach_outline = IoniconsData(0xe952);
+  static const IconData? attach_outline = IoniconsData(0xe952);
 
   /// attach-sharp
-  static const IconData attach_sharp = IoniconsData(0xe953);
+  static const IconData? attach_sharp = IoniconsData(0xe953);
 
   /// backspace
-  static const IconData backspace = IoniconsData(0xe954);
+  static const IconData? backspace = IoniconsData(0xe954);
 
   /// backspace-outline
-  static const IconData backspace_outline = IoniconsData(0xe955);
+  static const IconData? backspace_outline = IoniconsData(0xe955);
 
   /// backspace-sharp
-  static const IconData backspace_sharp = IoniconsData(0xe956);
+  static const IconData? backspace_sharp = IoniconsData(0xe956);
 
   /// bag
-  static const IconData bag = IoniconsData(0xe957);
+  static const IconData? bag = IoniconsData(0xe957);
 
   /// bag-add
-  static const IconData bag_add = IoniconsData(0xe958);
+  static const IconData? bag_add = IoniconsData(0xe958);
 
   /// bag-add-outline
-  static const IconData bag_add_outline = IoniconsData(0xe959);
+  static const IconData? bag_add_outline = IoniconsData(0xe959);
 
   /// bag-add-sharp
-  static const IconData bag_add_sharp = IoniconsData(0xe95a);
+  static const IconData? bag_add_sharp = IoniconsData(0xe95a);
 
   /// bag-check
-  static const IconData bag_check = IoniconsData(0xe95b);
+  static const IconData? bag_check = IoniconsData(0xe95b);
 
   /// bag-check-outline
-  static const IconData bag_check_outline = IoniconsData(0xe95c);
+  static const IconData? bag_check_outline = IoniconsData(0xe95c);
 
   /// bag-check-sharp
-  static const IconData bag_check_sharp = IoniconsData(0xe95d);
+  static const IconData? bag_check_sharp = IoniconsData(0xe95d);
 
   /// bag-handle
-  static const IconData bag_handle = IoniconsData(0xe95e);
+  static const IconData? bag_handle = IoniconsData(0xe95e);
 
   /// bag-handle-outline
-  static const IconData bag_handle_outline = IoniconsData(0xe95f);
+  static const IconData? bag_handle_outline = IoniconsData(0xe95f);
 
   /// bag-handle-sharp
-  static const IconData bag_handle_sharp = IoniconsData(0xe960);
+  static const IconData? bag_handle_sharp = IoniconsData(0xe960);
 
   /// bag-outline
-  static const IconData bag_outline = IoniconsData(0xe961);
+  static const IconData? bag_outline = IoniconsData(0xe961);
 
   /// bag-remove
-  static const IconData bag_remove = IoniconsData(0xe962);
+  static const IconData? bag_remove = IoniconsData(0xe962);
 
   /// bag-remove-outline
-  static const IconData bag_remove_outline = IoniconsData(0xe963);
+  static const IconData? bag_remove_outline = IoniconsData(0xe963);
 
   /// bag-remove-sharp
-  static const IconData bag_remove_sharp = IoniconsData(0xe964);
+  static const IconData? bag_remove_sharp = IoniconsData(0xe964);
 
   /// bag-sharp
-  static const IconData bag_sharp = IoniconsData(0xe965);
+  static const IconData? bag_sharp = IoniconsData(0xe965);
 
   /// balloon
-  static const IconData balloon = IoniconsData(0xe966);
+  static const IconData? balloon = IoniconsData(0xe966);
 
   /// balloon-outline
-  static const IconData balloon_outline = IoniconsData(0xe967);
+  static const IconData? balloon_outline = IoniconsData(0xe967);
 
   /// balloon-sharp
-  static const IconData balloon_sharp = IoniconsData(0xe968);
+  static const IconData? balloon_sharp = IoniconsData(0xe968);
 
   /// ban
-  static const IconData ban = IoniconsData(0xe969);
+  static const IconData? ban = IoniconsData(0xe969);
 
   /// bandage
-  static const IconData bandage = IoniconsData(0xe96a);
+  static const IconData? bandage = IoniconsData(0xe96a);
 
   /// bandage-outline
-  static const IconData bandage_outline = IoniconsData(0xe96b);
+  static const IconData? bandage_outline = IoniconsData(0xe96b);
 
   /// bandage-sharp
-  static const IconData bandage_sharp = IoniconsData(0xe96c);
+  static const IconData? bandage_sharp = IoniconsData(0xe96c);
 
   /// ban-outline
-  static const IconData ban_outline = IoniconsData(0xe96d);
+  static const IconData? ban_outline = IoniconsData(0xe96d);
 
   /// ban-sharp
-  static const IconData ban_sharp = IoniconsData(0xe96e);
+  static const IconData? ban_sharp = IoniconsData(0xe96e);
 
   /// barbell
-  static const IconData barbell = IoniconsData(0xe96f);
+  static const IconData? barbell = IoniconsData(0xe96f);
 
   /// barbell-outline
-  static const IconData barbell_outline = IoniconsData(0xe970);
+  static const IconData? barbell_outline = IoniconsData(0xe970);
 
   /// barbell-sharp
-  static const IconData barbell_sharp = IoniconsData(0xe971);
+  static const IconData? barbell_sharp = IoniconsData(0xe971);
 
   /// bar-chart
-  static const IconData bar_chart = IoniconsData(0xe972);
+  static const IconData? bar_chart = IoniconsData(0xe972);
 
   /// bar-chart-outline
-  static const IconData bar_chart_outline = IoniconsData(0xe973);
+  static const IconData? bar_chart_outline = IoniconsData(0xe973);
 
   /// bar-chart-sharp
-  static const IconData bar_chart_sharp = IoniconsData(0xe974);
+  static const IconData? bar_chart_sharp = IoniconsData(0xe974);
 
   /// barcode
-  static const IconData barcode = IoniconsData(0xe975);
+  static const IconData? barcode = IoniconsData(0xe975);
 
   /// barcode-outline
-  static const IconData barcode_outline = IoniconsData(0xe976);
+  static const IconData? barcode_outline = IoniconsData(0xe976);
 
   /// barcode-sharp
-  static const IconData barcode_sharp = IoniconsData(0xe977);
+  static const IconData? barcode_sharp = IoniconsData(0xe977);
 
   /// baseball
-  static const IconData baseball = IoniconsData(0xe978);
+  static const IconData? baseball = IoniconsData(0xe978);
 
   /// baseball-outline
-  static const IconData baseball_outline = IoniconsData(0xe979);
+  static const IconData? baseball_outline = IoniconsData(0xe979);
 
   /// baseball-sharp
-  static const IconData baseball_sharp = IoniconsData(0xe97a);
+  static const IconData? baseball_sharp = IoniconsData(0xe97a);
 
   /// basket
-  static const IconData basket = IoniconsData(0xe97b);
+  static const IconData? basket = IoniconsData(0xe97b);
 
   /// basketball
-  static const IconData basketball = IoniconsData(0xe97c);
+  static const IconData? basketball = IoniconsData(0xe97c);
 
   /// basketball-outline
-  static const IconData basketball_outline = IoniconsData(0xe97d);
+  static const IconData? basketball_outline = IoniconsData(0xe97d);
 
   /// basketball-sharp
-  static const IconData basketball_sharp = IoniconsData(0xe97e);
+  static const IconData? basketball_sharp = IoniconsData(0xe97e);
 
   /// basket-outline
-  static const IconData basket_outline = IoniconsData(0xe97f);
+  static const IconData? basket_outline = IoniconsData(0xe97f);
 
   /// basket-sharp
-  static const IconData basket_sharp = IoniconsData(0xe980);
+  static const IconData? basket_sharp = IoniconsData(0xe980);
 
   /// battery-charging
-  static const IconData battery_charging = IoniconsData(0xe981);
+  static const IconData? battery_charging = IoniconsData(0xe981);
 
   /// battery-charging-outline
-  static const IconData battery_charging_outline = IoniconsData(0xe982);
+  static const IconData? battery_charging_outline = IoniconsData(0xe982);
 
   /// battery-charging-sharp
-  static const IconData battery_charging_sharp = IoniconsData(0xe983);
+  static const IconData? battery_charging_sharp = IoniconsData(0xe983);
 
   /// battery-dead
-  static const IconData battery_dead = IoniconsData(0xe984);
+  static const IconData? battery_dead = IoniconsData(0xe984);
 
   /// battery-dead-outline
-  static const IconData battery_dead_outline = IoniconsData(0xe985);
+  static const IconData? battery_dead_outline = IoniconsData(0xe985);
 
   /// battery-dead-sharp
-  static const IconData battery_dead_sharp = IoniconsData(0xe986);
+  static const IconData? battery_dead_sharp = IoniconsData(0xe986);
 
   /// battery-full
-  static const IconData battery_full = IoniconsData(0xe987);
+  static const IconData? battery_full = IoniconsData(0xe987);
 
   /// battery-full-outline
-  static const IconData battery_full_outline = IoniconsData(0xe988);
+  static const IconData? battery_full_outline = IoniconsData(0xe988);
 
   /// battery-full-sharp
-  static const IconData battery_full_sharp = IoniconsData(0xe989);
+  static const IconData? battery_full_sharp = IoniconsData(0xe989);
 
   /// battery-half
-  static const IconData battery_half = IoniconsData(0xe98a);
+  static const IconData? battery_half = IoniconsData(0xe98a);
 
   /// battery-half-outline
-  static const IconData battery_half_outline = IoniconsData(0xe98b);
+  static const IconData? battery_half_outline = IoniconsData(0xe98b);
 
   /// battery-half-sharp
-  static const IconData battery_half_sharp = IoniconsData(0xe98c);
+  static const IconData? battery_half_sharp = IoniconsData(0xe98c);
 
   /// beaker
-  static const IconData beaker = IoniconsData(0xe98d);
+  static const IconData? beaker = IoniconsData(0xe98d);
 
   /// beaker-outline
-  static const IconData beaker_outline = IoniconsData(0xe98e);
+  static const IconData? beaker_outline = IoniconsData(0xe98e);
 
   /// beaker-sharp
-  static const IconData beaker_sharp = IoniconsData(0xe98f);
+  static const IconData? beaker_sharp = IoniconsData(0xe98f);
 
   /// bed
-  static const IconData bed = IoniconsData(0xe990);
+  static const IconData? bed = IoniconsData(0xe990);
 
   /// bed-outline
-  static const IconData bed_outline = IoniconsData(0xe991);
+  static const IconData? bed_outline = IoniconsData(0xe991);
 
   /// bed-sharp
-  static const IconData bed_sharp = IoniconsData(0xe992);
+  static const IconData? bed_sharp = IoniconsData(0xe992);
 
   /// beer
-  static const IconData beer = IoniconsData(0xe993);
+  static const IconData? beer = IoniconsData(0xe993);
 
   /// beer-outline
-  static const IconData beer_outline = IoniconsData(0xe994);
+  static const IconData? beer_outline = IoniconsData(0xe994);
 
   /// beer-sharp
-  static const IconData beer_sharp = IoniconsData(0xe995);
+  static const IconData? beer_sharp = IoniconsData(0xe995);
 
   /// bicycle
-  static const IconData bicycle = IoniconsData(0xe996);
+  static const IconData? bicycle = IoniconsData(0xe996);
 
   /// bicycle-outline
-  static const IconData bicycle_outline = IoniconsData(0xe997);
+  static const IconData? bicycle_outline = IoniconsData(0xe997);
 
   /// bicycle-sharp
-  static const IconData bicycle_sharp = IoniconsData(0xe998);
+  static const IconData? bicycle_sharp = IoniconsData(0xe998);
 
   /// bluetooth
-  static const IconData bluetooth = IoniconsData(0xe999);
+  static const IconData? bluetooth = IoniconsData(0xe999);
 
   /// bluetooth-outline
-  static const IconData bluetooth_outline = IoniconsData(0xe99a);
+  static const IconData? bluetooth_outline = IoniconsData(0xe99a);
 
   /// bluetooth-sharp
-  static const IconData bluetooth_sharp = IoniconsData(0xe99b);
+  static const IconData? bluetooth_sharp = IoniconsData(0xe99b);
 
   /// boat
-  static const IconData boat = IoniconsData(0xe99c);
+  static const IconData? boat = IoniconsData(0xe99c);
 
   /// boat-outline
-  static const IconData boat_outline = IoniconsData(0xe99d);
+  static const IconData? boat_outline = IoniconsData(0xe99d);
 
   /// boat-sharp
-  static const IconData boat_sharp = IoniconsData(0xe99e);
+  static const IconData? boat_sharp = IoniconsData(0xe99e);
 
   /// body
-  static const IconData body = IoniconsData(0xe99f);
+  static const IconData? body = IoniconsData(0xe99f);
 
   /// body-outline
-  static const IconData body_outline = IoniconsData(0xe9a0);
+  static const IconData? body_outline = IoniconsData(0xe9a0);
 
   /// body-sharp
-  static const IconData body_sharp = IoniconsData(0xe9a1);
+  static const IconData? body_sharp = IoniconsData(0xe9a1);
 
   /// bonfire
-  static const IconData bonfire = IoniconsData(0xe9a2);
+  static const IconData? bonfire = IoniconsData(0xe9a2);
 
   /// bonfire-outline
-  static const IconData bonfire_outline = IoniconsData(0xe9a3);
+  static const IconData? bonfire_outline = IoniconsData(0xe9a3);
 
   /// bonfire-sharp
-  static const IconData bonfire_sharp = IoniconsData(0xe9a4);
+  static const IconData? bonfire_sharp = IoniconsData(0xe9a4);
 
   /// book
-  static const IconData book = IoniconsData(0xe9a5);
+  static const IconData? book = IoniconsData(0xe9a5);
 
   /// bookmark
-  static const IconData bookmark = IoniconsData(0xe9a6);
+  static const IconData? bookmark = IoniconsData(0xe9a6);
 
   /// bookmark-outline
-  static const IconData bookmark_outline = IoniconsData(0xe9a7);
+  static const IconData? bookmark_outline = IoniconsData(0xe9a7);
 
   /// bookmarks
-  static const IconData bookmarks = IoniconsData(0xe9a8);
+  static const IconData? bookmarks = IoniconsData(0xe9a8);
 
   /// bookmark-sharp
-  static const IconData bookmark_sharp = IoniconsData(0xe9a9);
+  static const IconData? bookmark_sharp = IoniconsData(0xe9a9);
 
   /// bookmarks-outline
-  static const IconData bookmarks_outline = IoniconsData(0xe9aa);
+  static const IconData? bookmarks_outline = IoniconsData(0xe9aa);
 
   /// bookmarks-sharp
-  static const IconData bookmarks_sharp = IoniconsData(0xe9ab);
+  static const IconData? bookmarks_sharp = IoniconsData(0xe9ab);
 
   /// book-outline
-  static const IconData book_outline = IoniconsData(0xe9ac);
+  static const IconData? book_outline = IoniconsData(0xe9ac);
 
   /// book-sharp
-  static const IconData book_sharp = IoniconsData(0xe9ad);
+  static const IconData? book_sharp = IoniconsData(0xe9ad);
 
   /// bowling-ball
-  static const IconData bowling_ball = IoniconsData(0xe9ae);
+  static const IconData? bowling_ball = IoniconsData(0xe9ae);
 
   /// bowling-ball-outline
-  static const IconData bowling_ball_outline = IoniconsData(0xe9af);
+  static const IconData? bowling_ball_outline = IoniconsData(0xe9af);
 
   /// bowling-ball-sharp
-  static const IconData bowling_ball_sharp = IoniconsData(0xe9b0);
+  static const IconData? bowling_ball_sharp = IoniconsData(0xe9b0);
 
   /// briefcase
-  static const IconData briefcase = IoniconsData(0xe9b1);
+  static const IconData? briefcase = IoniconsData(0xe9b1);
 
   /// briefcase-outline
-  static const IconData briefcase_outline = IoniconsData(0xe9b2);
+  static const IconData? briefcase_outline = IoniconsData(0xe9b2);
 
   /// briefcase-sharp
-  static const IconData briefcase_sharp = IoniconsData(0xe9b3);
+  static const IconData? briefcase_sharp = IoniconsData(0xe9b3);
 
   /// browsers
-  static const IconData browsers = IoniconsData(0xe9b4);
+  static const IconData? browsers = IoniconsData(0xe9b4);
 
   /// browsers-outline
-  static const IconData browsers_outline = IoniconsData(0xe9b5);
+  static const IconData? browsers_outline = IoniconsData(0xe9b5);
 
   /// browsers-sharp
-  static const IconData browsers_sharp = IoniconsData(0xe9b6);
+  static const IconData? browsers_sharp = IoniconsData(0xe9b6);
 
   /// brush
-  static const IconData brush = IoniconsData(0xe9b7);
+  static const IconData? brush = IoniconsData(0xe9b7);
 
   /// brush-outline
-  static const IconData brush_outline = IoniconsData(0xe9b8);
+  static const IconData? brush_outline = IoniconsData(0xe9b8);
 
   /// brush-sharp
-  static const IconData brush_sharp = IoniconsData(0xe9b9);
+  static const IconData? brush_sharp = IoniconsData(0xe9b9);
 
   /// bug
-  static const IconData bug = IoniconsData(0xe9ba);
+  static const IconData? bug = IoniconsData(0xe9ba);
 
   /// bug-outline
-  static const IconData bug_outline = IoniconsData(0xe9bb);
+  static const IconData? bug_outline = IoniconsData(0xe9bb);
 
   /// bug-sharp
-  static const IconData bug_sharp = IoniconsData(0xe9bc);
+  static const IconData? bug_sharp = IoniconsData(0xe9bc);
 
   /// build
-  static const IconData build = IoniconsData(0xe9bd);
+  static const IconData? build = IoniconsData(0xe9bd);
 
   /// build-outline
-  static const IconData build_outline = IoniconsData(0xe9be);
+  static const IconData? build_outline = IoniconsData(0xe9be);
 
   /// build-sharp
-  static const IconData build_sharp = IoniconsData(0xe9bf);
+  static const IconData? build_sharp = IoniconsData(0xe9bf);
 
   /// bulb
-  static const IconData bulb = IoniconsData(0xe9c0);
+  static const IconData? bulb = IoniconsData(0xe9c0);
 
   /// bulb-outline
-  static const IconData bulb_outline = IoniconsData(0xe9c1);
+  static const IconData? bulb_outline = IoniconsData(0xe9c1);
 
   /// bulb-sharp
-  static const IconData bulb_sharp = IoniconsData(0xe9c2);
+  static const IconData? bulb_sharp = IoniconsData(0xe9c2);
 
   /// bus
-  static const IconData bus = IoniconsData(0xe9c3);
+  static const IconData? bus = IoniconsData(0xe9c3);
 
   /// business
-  static const IconData business = IoniconsData(0xe9c4);
+  static const IconData? business = IoniconsData(0xe9c4);
 
   /// business-outline
-  static const IconData business_outline = IoniconsData(0xe9c5);
+  static const IconData? business_outline = IoniconsData(0xe9c5);
 
   /// business-sharp
-  static const IconData business_sharp = IoniconsData(0xe9c6);
+  static const IconData? business_sharp = IoniconsData(0xe9c6);
 
   /// bus-outline
-  static const IconData bus_outline = IoniconsData(0xe9c7);
+  static const IconData? bus_outline = IoniconsData(0xe9c7);
 
   /// bus-sharp
-  static const IconData bus_sharp = IoniconsData(0xe9c8);
+  static const IconData? bus_sharp = IoniconsData(0xe9c8);
 
   /// cafe
-  static const IconData cafe = IoniconsData(0xe9c9);
+  static const IconData? cafe = IoniconsData(0xe9c9);
 
   /// cafe-outline
-  static const IconData cafe_outline = IoniconsData(0xe9ca);
+  static const IconData? cafe_outline = IoniconsData(0xe9ca);
 
   /// cafe-sharp
-  static const IconData cafe_sharp = IoniconsData(0xe9cb);
+  static const IconData? cafe_sharp = IoniconsData(0xe9cb);
 
   /// calculator
-  static const IconData calculator = IoniconsData(0xe9cc);
+  static const IconData? calculator = IoniconsData(0xe9cc);
 
   /// calculator-outline
-  static const IconData calculator_outline = IoniconsData(0xe9cd);
+  static const IconData? calculator_outline = IoniconsData(0xe9cd);
 
   /// calculator-sharp
-  static const IconData calculator_sharp = IoniconsData(0xe9ce);
+  static const IconData? calculator_sharp = IoniconsData(0xe9ce);
 
   /// calendar
-  static const IconData calendar = IoniconsData(0xe9cf);
+  static const IconData? calendar = IoniconsData(0xe9cf);
 
   /// calendar-clear
-  static const IconData calendar_clear = IoniconsData(0xe9d0);
+  static const IconData? calendar_clear = IoniconsData(0xe9d0);
 
   /// calendar-clear-outline
-  static const IconData calendar_clear_outline = IoniconsData(0xe9d1);
+  static const IconData? calendar_clear_outline = IoniconsData(0xe9d1);
 
   /// calendar-clear-sharp
-  static const IconData calendar_clear_sharp = IoniconsData(0xe9d2);
+  static const IconData? calendar_clear_sharp = IoniconsData(0xe9d2);
 
   /// calendar-number
-  static const IconData calendar_number = IoniconsData(0xe9d3);
+  static const IconData? calendar_number = IoniconsData(0xe9d3);
 
   /// calendar-number-outline
-  static const IconData calendar_number_outline = IoniconsData(0xe9d4);
+  static const IconData? calendar_number_outline = IoniconsData(0xe9d4);
 
   /// calendar-number-sharp
-  static const IconData calendar_number_sharp = IoniconsData(0xe9d5);
+  static const IconData? calendar_number_sharp = IoniconsData(0xe9d5);
 
   /// calendar-outline
-  static const IconData calendar_outline = IoniconsData(0xe9d6);
+  static const IconData? calendar_outline = IoniconsData(0xe9d6);
 
   /// calendar-sharp
-  static const IconData calendar_sharp = IoniconsData(0xe9d7);
+  static const IconData? calendar_sharp = IoniconsData(0xe9d7);
 
   /// call
-  static const IconData call = IoniconsData(0xe9d8);
+  static const IconData? call = IoniconsData(0xe9d8);
 
   /// call-outline
-  static const IconData call_outline = IoniconsData(0xe9d9);
+  static const IconData? call_outline = IoniconsData(0xe9d9);
 
   /// call-sharp
-  static const IconData call_sharp = IoniconsData(0xe9da);
+  static const IconData? call_sharp = IoniconsData(0xe9da);
 
   /// camera
-  static const IconData camera = IoniconsData(0xe9db);
+  static const IconData? camera = IoniconsData(0xe9db);
 
   /// camera-outline
-  static const IconData camera_outline = IoniconsData(0xe9dc);
+  static const IconData? camera_outline = IoniconsData(0xe9dc);
 
   /// camera-reverse
-  static const IconData camera_reverse = IoniconsData(0xe9dd);
+  static const IconData? camera_reverse = IoniconsData(0xe9dd);
 
   /// camera-reverse-outline
-  static const IconData camera_reverse_outline = IoniconsData(0xe9de);
+  static const IconData? camera_reverse_outline = IoniconsData(0xe9de);
 
   /// camera-reverse-sharp
-  static const IconData camera_reverse_sharp = IoniconsData(0xe9df);
+  static const IconData? camera_reverse_sharp = IoniconsData(0xe9df);
 
   /// camera-sharp
-  static const IconData camera_sharp = IoniconsData(0xe9e0);
+  static const IconData? camera_sharp = IoniconsData(0xe9e0);
 
   /// car
-  static const IconData car = IoniconsData(0xe9e1);
+  static const IconData? car = IoniconsData(0xe9e1);
 
   /// card
-  static const IconData card = IoniconsData(0xe9e2);
+  static const IconData? card = IoniconsData(0xe9e2);
 
   /// card-outline
-  static const IconData card_outline = IoniconsData(0xe9e3);
+  static const IconData? card_outline = IoniconsData(0xe9e3);
 
   /// card-sharp
-  static const IconData card_sharp = IoniconsData(0xe9e4);
+  static const IconData? card_sharp = IoniconsData(0xe9e4);
 
   /// caret-back
-  static const IconData caret_back = IoniconsData(0xe9e5);
+  static const IconData? caret_back = IoniconsData(0xe9e5);
 
   /// caret-back-circle
-  static const IconData caret_back_circle = IoniconsData(0xe9e6);
+  static const IconData? caret_back_circle = IoniconsData(0xe9e6);
 
   /// caret-back-circle-outline
-  static const IconData caret_back_circle_outline = IoniconsData(0xe9e7);
+  static const IconData? caret_back_circle_outline = IoniconsData(0xe9e7);
 
   /// caret-back-circle-sharp
-  static const IconData caret_back_circle_sharp = IoniconsData(0xe9e8);
+  static const IconData? caret_back_circle_sharp = IoniconsData(0xe9e8);
 
   /// caret-back-outline
-  static const IconData caret_back_outline = IoniconsData(0xe9e9);
+  static const IconData? caret_back_outline = IoniconsData(0xe9e9);
 
   /// caret-back-sharp
-  static const IconData caret_back_sharp = IoniconsData(0xe9ea);
+  static const IconData? caret_back_sharp = IoniconsData(0xe9ea);
 
   /// caret-down
-  static const IconData caret_down = IoniconsData(0xe9eb);
+  static const IconData? caret_down = IoniconsData(0xe9eb);
 
   /// caret-down-circle
-  static const IconData caret_down_circle = IoniconsData(0xe9ec);
+  static const IconData? caret_down_circle = IoniconsData(0xe9ec);
 
   /// caret-down-circle-outline
-  static const IconData caret_down_circle_outline = IoniconsData(0xe9ed);
+  static const IconData? caret_down_circle_outline = IoniconsData(0xe9ed);
 
   /// caret-down-circle-sharp
-  static const IconData caret_down_circle_sharp = IoniconsData(0xe9ee);
+  static const IconData? caret_down_circle_sharp = IoniconsData(0xe9ee);
 
   /// caret-down-outline
-  static const IconData caret_down_outline = IoniconsData(0xe9ef);
+  static const IconData? caret_down_outline = IoniconsData(0xe9ef);
 
   /// caret-down-sharp
-  static const IconData caret_down_sharp = IoniconsData(0xe9f0);
+  static const IconData? caret_down_sharp = IoniconsData(0xe9f0);
 
   /// caret-forward
-  static const IconData caret_forward = IoniconsData(0xe9f1);
+  static const IconData? caret_forward = IoniconsData(0xe9f1);
 
   /// caret-forward-circle
-  static const IconData caret_forward_circle = IoniconsData(0xe9f2);
+  static const IconData? caret_forward_circle = IoniconsData(0xe9f2);
 
   /// caret-forward-circle-outline
-  static const IconData caret_forward_circle_outline = IoniconsData(0xe9f3);
+  static const IconData? caret_forward_circle_outline = IoniconsData(0xe9f3);
 
   /// caret-forward-circle-sharp
-  static const IconData caret_forward_circle_sharp = IoniconsData(0xe9f4);
+  static const IconData? caret_forward_circle_sharp = IoniconsData(0xe9f4);
 
   /// caret-forward-outline
-  static const IconData caret_forward_outline = IoniconsData(0xe9f5);
+  static const IconData? caret_forward_outline = IoniconsData(0xe9f5);
 
   /// caret-forward-sharp
-  static const IconData caret_forward_sharp = IoniconsData(0xe9f6);
+  static const IconData? caret_forward_sharp = IoniconsData(0xe9f6);
 
   /// caret-up
-  static const IconData caret_up = IoniconsData(0xe9f7);
+  static const IconData? caret_up = IoniconsData(0xe9f7);
 
   /// caret-up-circle
-  static const IconData caret_up_circle = IoniconsData(0xe9f8);
+  static const IconData? caret_up_circle = IoniconsData(0xe9f8);
 
   /// caret-up-circle-outline
-  static const IconData caret_up_circle_outline = IoniconsData(0xe9f9);
+  static const IconData? caret_up_circle_outline = IoniconsData(0xe9f9);
 
   /// caret-up-circle-sharp
-  static const IconData caret_up_circle_sharp = IoniconsData(0xe9fa);
+  static const IconData? caret_up_circle_sharp = IoniconsData(0xe9fa);
 
   /// caret-up-outline
-  static const IconData caret_up_outline = IoniconsData(0xe9fb);
+  static const IconData? caret_up_outline = IoniconsData(0xe9fb);
 
   /// caret-up-sharp
-  static const IconData caret_up_sharp = IoniconsData(0xe9fc);
+  static const IconData? caret_up_sharp = IoniconsData(0xe9fc);
 
   /// car-outline
-  static const IconData car_outline = IoniconsData(0xe9fd);
+  static const IconData? car_outline = IoniconsData(0xe9fd);
 
   /// car-sharp
-  static const IconData car_sharp = IoniconsData(0xe9fe);
+  static const IconData? car_sharp = IoniconsData(0xe9fe);
 
   /// car-sport
-  static const IconData car_sport = IoniconsData(0xe9ff);
+  static const IconData? car_sport = IoniconsData(0xe9ff);
 
   /// car-sport-outline
-  static const IconData car_sport_outline = IoniconsData(0xea00);
+  static const IconData? car_sport_outline = IoniconsData(0xea00);
 
   /// car-sport-sharp
-  static const IconData car_sport_sharp = IoniconsData(0xea01);
+  static const IconData? car_sport_sharp = IoniconsData(0xea01);
 
   /// cart
-  static const IconData cart = IoniconsData(0xea02);
+  static const IconData? cart = IoniconsData(0xea02);
 
   /// cart-outline
-  static const IconData cart_outline = IoniconsData(0xea03);
+  static const IconData? cart_outline = IoniconsData(0xea03);
 
   /// cart-sharp
-  static const IconData cart_sharp = IoniconsData(0xea04);
+  static const IconData? cart_sharp = IoniconsData(0xea04);
 
   /// cash
-  static const IconData cash = IoniconsData(0xea05);
+  static const IconData? cash = IoniconsData(0xea05);
 
   /// cash-outline
-  static const IconData cash_outline = IoniconsData(0xea06);
+  static const IconData? cash_outline = IoniconsData(0xea06);
 
   /// cash-sharp
-  static const IconData cash_sharp = IoniconsData(0xea07);
+  static const IconData? cash_sharp = IoniconsData(0xea07);
 
   /// cellular
-  static const IconData cellular = IoniconsData(0xea08);
+  static const IconData? cellular = IoniconsData(0xea08);
 
   /// cellular-outline
-  static const IconData cellular_outline = IoniconsData(0xea09);
+  static const IconData? cellular_outline = IoniconsData(0xea09);
 
   /// cellular-sharp
-  static const IconData cellular_sharp = IoniconsData(0xea0a);
+  static const IconData? cellular_sharp = IoniconsData(0xea0a);
 
   /// chatbox
-  static const IconData chatbox = IoniconsData(0xea0b);
+  static const IconData? chatbox = IoniconsData(0xea0b);
 
   /// chatbox-ellipses
-  static const IconData chatbox_ellipses = IoniconsData(0xea0c);
+  static const IconData? chatbox_ellipses = IoniconsData(0xea0c);
 
   /// chatbox-ellipses-outline
-  static const IconData chatbox_ellipses_outline = IoniconsData(0xea0d);
+  static const IconData? chatbox_ellipses_outline = IoniconsData(0xea0d);
 
   /// chatbox-ellipses-sharp
-  static const IconData chatbox_ellipses_sharp = IoniconsData(0xea0e);
+  static const IconData? chatbox_ellipses_sharp = IoniconsData(0xea0e);
 
   /// chatbox-outline
-  static const IconData chatbox_outline = IoniconsData(0xea0f);
+  static const IconData? chatbox_outline = IoniconsData(0xea0f);
 
   /// chatbox-sharp
-  static const IconData chatbox_sharp = IoniconsData(0xea10);
+  static const IconData? chatbox_sharp = IoniconsData(0xea10);
 
   /// chatbubble
-  static const IconData chatbubble = IoniconsData(0xea11);
+  static const IconData? chatbubble = IoniconsData(0xea11);
 
   /// chatbubble-ellipses
-  static const IconData chatbubble_ellipses = IoniconsData(0xea12);
+  static const IconData? chatbubble_ellipses = IoniconsData(0xea12);
 
   /// chatbubble-ellipses-outline
-  static const IconData chatbubble_ellipses_outline = IoniconsData(0xea13);
+  static const IconData? chatbubble_ellipses_outline = IoniconsData(0xea13);
 
   /// chatbubble-ellipses-sharp
-  static const IconData chatbubble_ellipses_sharp = IoniconsData(0xea14);
+  static const IconData? chatbubble_ellipses_sharp = IoniconsData(0xea14);
 
   /// chatbubble-outline
-  static const IconData chatbubble_outline = IoniconsData(0xea15);
+  static const IconData? chatbubble_outline = IoniconsData(0xea15);
 
   /// chatbubbles
-  static const IconData chatbubbles = IoniconsData(0xea16);
+  static const IconData? chatbubbles = IoniconsData(0xea16);
 
   /// chatbubble-sharp
-  static const IconData chatbubble_sharp = IoniconsData(0xea17);
+  static const IconData? chatbubble_sharp = IoniconsData(0xea17);
 
   /// chatbubbles-outline
-  static const IconData chatbubbles_outline = IoniconsData(0xea18);
+  static const IconData? chatbubbles_outline = IoniconsData(0xea18);
 
   /// chatbubbles-sharp
-  static const IconData chatbubbles_sharp = IoniconsData(0xea19);
+  static const IconData? chatbubbles_sharp = IoniconsData(0xea19);
 
   /// checkbox
-  static const IconData checkbox = IoniconsData(0xea1a);
+  static const IconData? checkbox = IoniconsData(0xea1a);
 
   /// checkbox-outline
-  static const IconData checkbox_outline = IoniconsData(0xea1b);
+  static const IconData? checkbox_outline = IoniconsData(0xea1b);
 
   /// checkbox-sharp
-  static const IconData checkbox_sharp = IoniconsData(0xea1c);
+  static const IconData? checkbox_sharp = IoniconsData(0xea1c);
 
   /// checkmark
-  static const IconData checkmark = IoniconsData(0xea1d);
+  static const IconData? checkmark = IoniconsData(0xea1d);
 
   /// checkmark-circle
-  static const IconData checkmark_circle = IoniconsData(0xea1e);
+  static const IconData? checkmark_circle = IoniconsData(0xea1e);
 
   /// checkmark-circle-outline
-  static const IconData checkmark_circle_outline = IoniconsData(0xea1f);
+  static const IconData? checkmark_circle_outline = IoniconsData(0xea1f);
 
   /// checkmark-circle-sharp
-  static const IconData checkmark_circle_sharp = IoniconsData(0xea20);
+  static const IconData? checkmark_circle_sharp = IoniconsData(0xea20);
 
   /// checkmark-done
-  static const IconData checkmark_done = IoniconsData(0xea21);
+  static const IconData? checkmark_done = IoniconsData(0xea21);
 
   /// checkmark-done-circle
-  static const IconData checkmark_done_circle = IoniconsData(0xea22);
+  static const IconData? checkmark_done_circle = IoniconsData(0xea22);
 
   /// checkmark-done-circle-outline
-  static const IconData checkmark_done_circle_outline = IoniconsData(0xea23);
+  static const IconData? checkmark_done_circle_outline = IoniconsData(0xea23);
 
   /// checkmark-done-circle-sharp
-  static const IconData checkmark_done_circle_sharp = IoniconsData(0xea24);
+  static const IconData? checkmark_done_circle_sharp = IoniconsData(0xea24);
 
   /// checkmark-done-outline
-  static const IconData checkmark_done_outline = IoniconsData(0xea25);
+  static const IconData? checkmark_done_outline = IoniconsData(0xea25);
 
   /// checkmark-done-sharp
-  static const IconData checkmark_done_sharp = IoniconsData(0xea26);
+  static const IconData? checkmark_done_sharp = IoniconsData(0xea26);
 
   /// checkmark-outline
-  static const IconData checkmark_outline = IoniconsData(0xea27);
+  static const IconData? checkmark_outline = IoniconsData(0xea27);
 
   /// checkmark-sharp
-  static const IconData checkmark_sharp = IoniconsData(0xea28);
+  static const IconData? checkmark_sharp = IoniconsData(0xea28);
 
   /// chevron-back
-  static const IconData chevron_back = IoniconsData(0xea29);
+  static const IconData? chevron_back = IoniconsData(0xea29);
 
   /// chevron-back-circle
-  static const IconData chevron_back_circle = IoniconsData(0xea2a);
+  static const IconData? chevron_back_circle = IoniconsData(0xea2a);
 
   /// chevron-back-circle-outline
-  static const IconData chevron_back_circle_outline = IoniconsData(0xea2b);
+  static const IconData? chevron_back_circle_outline = IoniconsData(0xea2b);
 
   /// chevron-back-circle-sharp
-  static const IconData chevron_back_circle_sharp = IoniconsData(0xea2c);
+  static const IconData? chevron_back_circle_sharp = IoniconsData(0xea2c);
 
   /// chevron-back-outline
-  static const IconData chevron_back_outline = IoniconsData(0xea2d);
+  static const IconData? chevron_back_outline = IoniconsData(0xea2d);
 
   /// chevron-back-sharp
-  static const IconData chevron_back_sharp = IoniconsData(0xea2e);
+  static const IconData? chevron_back_sharp = IoniconsData(0xea2e);
 
   /// chevron-down
-  static const IconData chevron_down = IoniconsData(0xea2f);
+  static const IconData? chevron_down = IoniconsData(0xea2f);
 
   /// chevron-down-circle
-  static const IconData chevron_down_circle = IoniconsData(0xea30);
+  static const IconData? chevron_down_circle = IoniconsData(0xea30);
 
   /// chevron-down-circle-outline
-  static const IconData chevron_down_circle_outline = IoniconsData(0xea31);
+  static const IconData? chevron_down_circle_outline = IoniconsData(0xea31);
 
   /// chevron-down-circle-sharp
-  static const IconData chevron_down_circle_sharp = IoniconsData(0xea32);
+  static const IconData? chevron_down_circle_sharp = IoniconsData(0xea32);
 
   /// chevron-down-outline
-  static const IconData chevron_down_outline = IoniconsData(0xea33);
+  static const IconData? chevron_down_outline = IoniconsData(0xea33);
 
   /// chevron-down-sharp
-  static const IconData chevron_down_sharp = IoniconsData(0xea34);
+  static const IconData? chevron_down_sharp = IoniconsData(0xea34);
 
   /// chevron-forward
-  static const IconData chevron_forward = IoniconsData(0xea35);
+  static const IconData? chevron_forward = IoniconsData(0xea35);
 
   /// chevron-forward-circle
-  static const IconData chevron_forward_circle = IoniconsData(0xea36);
+  static const IconData? chevron_forward_circle = IoniconsData(0xea36);
 
   /// chevron-forward-circle-outline
-  static const IconData chevron_forward_circle_outline = IoniconsData(0xea37);
+  static const IconData? chevron_forward_circle_outline = IoniconsData(0xea37);
 
   /// chevron-forward-circle-sharp
-  static const IconData chevron_forward_circle_sharp = IoniconsData(0xea38);
+  static const IconData? chevron_forward_circle_sharp = IoniconsData(0xea38);
 
   /// chevron-forward-outline
-  static const IconData chevron_forward_outline = IoniconsData(0xea39);
+  static const IconData? chevron_forward_outline = IoniconsData(0xea39);
 
   /// chevron-forward-sharp
-  static const IconData chevron_forward_sharp = IoniconsData(0xea3a);
+  static const IconData? chevron_forward_sharp = IoniconsData(0xea3a);
 
   /// chevron-up
-  static const IconData chevron_up = IoniconsData(0xea3b);
+  static const IconData? chevron_up = IoniconsData(0xea3b);
 
   /// chevron-up-circle
-  static const IconData chevron_up_circle = IoniconsData(0xea3c);
+  static const IconData? chevron_up_circle = IoniconsData(0xea3c);
 
   /// chevron-up-circle-outline
-  static const IconData chevron_up_circle_outline = IoniconsData(0xea3d);
+  static const IconData? chevron_up_circle_outline = IoniconsData(0xea3d);
 
   /// chevron-up-circle-sharp
-  static const IconData chevron_up_circle_sharp = IoniconsData(0xea3e);
+  static const IconData? chevron_up_circle_sharp = IoniconsData(0xea3e);
 
   /// chevron-up-outline
-  static const IconData chevron_up_outline = IoniconsData(0xea3f);
+  static const IconData? chevron_up_outline = IoniconsData(0xea3f);
 
   /// chevron-up-sharp
-  static const IconData chevron_up_sharp = IoniconsData(0xea40);
+  static const IconData? chevron_up_sharp = IoniconsData(0xea40);
 
   /// clipboard
-  static const IconData clipboard = IoniconsData(0xea41);
+  static const IconData? clipboard = IoniconsData(0xea41);
 
   /// clipboard-outline
-  static const IconData clipboard_outline = IoniconsData(0xea42);
+  static const IconData? clipboard_outline = IoniconsData(0xea42);
 
   /// clipboard-sharp
-  static const IconData clipboard_sharp = IoniconsData(0xea43);
+  static const IconData? clipboard_sharp = IoniconsData(0xea43);
 
   /// close
-  static const IconData close = IoniconsData(0xea44);
+  static const IconData? close = IoniconsData(0xea44);
 
   /// close-circle
-  static const IconData close_circle = IoniconsData(0xea45);
+  static const IconData? close_circle = IoniconsData(0xea45);
 
   /// close-circle-outline
-  static const IconData close_circle_outline = IoniconsData(0xea46);
+  static const IconData? close_circle_outline = IoniconsData(0xea46);
 
   /// close-circle-sharp
-  static const IconData close_circle_sharp = IoniconsData(0xea47);
+  static const IconData? close_circle_sharp = IoniconsData(0xea47);
 
   /// close-outline
-  static const IconData close_outline = IoniconsData(0xea48);
+  static const IconData? close_outline = IoniconsData(0xea48);
 
   /// close-sharp
-  static const IconData close_sharp = IoniconsData(0xea49);
+  static const IconData? close_sharp = IoniconsData(0xea49);
 
   /// cloud
-  static const IconData cloud = IoniconsData(0xea4a);
+  static const IconData? cloud = IoniconsData(0xea4a);
 
   /// cloud-circle
-  static const IconData cloud_circle = IoniconsData(0xea4b);
+  static const IconData? cloud_circle = IoniconsData(0xea4b);
 
   /// cloud-circle-outline
-  static const IconData cloud_circle_outline = IoniconsData(0xea4c);
+  static const IconData? cloud_circle_outline = IoniconsData(0xea4c);
 
   /// cloud-circle-sharp
-  static const IconData cloud_circle_sharp = IoniconsData(0xea4d);
+  static const IconData? cloud_circle_sharp = IoniconsData(0xea4d);
 
   /// cloud-done
-  static const IconData cloud_done = IoniconsData(0xea4e);
+  static const IconData? cloud_done = IoniconsData(0xea4e);
 
   /// cloud-done-outline
-  static const IconData cloud_done_outline = IoniconsData(0xea4f);
+  static const IconData? cloud_done_outline = IoniconsData(0xea4f);
 
   /// cloud-done-sharp
-  static const IconData cloud_done_sharp = IoniconsData(0xea50);
+  static const IconData? cloud_done_sharp = IoniconsData(0xea50);
 
   /// cloud-download
-  static const IconData cloud_download = IoniconsData(0xea51);
+  static const IconData? cloud_download = IoniconsData(0xea51);
 
   /// cloud-download-outline
-  static const IconData cloud_download_outline = IoniconsData(0xea52);
+  static const IconData? cloud_download_outline = IoniconsData(0xea52);
 
   /// cloud-download-sharp
-  static const IconData cloud_download_sharp = IoniconsData(0xea53);
+  static const IconData? cloud_download_sharp = IoniconsData(0xea53);
 
   /// cloud-offline
-  static const IconData cloud_offline = IoniconsData(0xea54);
+  static const IconData? cloud_offline = IoniconsData(0xea54);
 
   /// cloud-offline-outline
-  static const IconData cloud_offline_outline = IoniconsData(0xea55);
+  static const IconData? cloud_offline_outline = IoniconsData(0xea55);
 
   /// cloud-offline-sharp
-  static const IconData cloud_offline_sharp = IoniconsData(0xea56);
+  static const IconData? cloud_offline_sharp = IoniconsData(0xea56);
 
   /// cloud-outline
-  static const IconData cloud_outline = IoniconsData(0xea57);
+  static const IconData? cloud_outline = IoniconsData(0xea57);
 
   /// cloud-sharp
-  static const IconData cloud_sharp = IoniconsData(0xea58);
+  static const IconData? cloud_sharp = IoniconsData(0xea58);
 
   /// cloud-upload
-  static const IconData cloud_upload = IoniconsData(0xea59);
+  static const IconData? cloud_upload = IoniconsData(0xea59);
 
   /// cloud-upload-outline
-  static const IconData cloud_upload_outline = IoniconsData(0xea5a);
+  static const IconData? cloud_upload_outline = IoniconsData(0xea5a);
 
   /// cloud-upload-sharp
-  static const IconData cloud_upload_sharp = IoniconsData(0xea5b);
+  static const IconData? cloud_upload_sharp = IoniconsData(0xea5b);
 
   /// cloudy
-  static const IconData cloudy = IoniconsData(0xea5c);
+  static const IconData? cloudy = IoniconsData(0xea5c);
 
   /// cloudy-night
-  static const IconData cloudy_night = IoniconsData(0xea5d);
+  static const IconData? cloudy_night = IoniconsData(0xea5d);
 
   /// cloudy-night-outline
-  static const IconData cloudy_night_outline = IoniconsData(0xea5e);
+  static const IconData? cloudy_night_outline = IoniconsData(0xea5e);
 
   /// cloudy-night-sharp
-  static const IconData cloudy_night_sharp = IoniconsData(0xea5f);
+  static const IconData? cloudy_night_sharp = IoniconsData(0xea5f);
 
   /// cloudy-outline
-  static const IconData cloudy_outline = IoniconsData(0xea60);
+  static const IconData? cloudy_outline = IoniconsData(0xea60);
 
   /// cloudy-sharp
-  static const IconData cloudy_sharp = IoniconsData(0xea61);
+  static const IconData? cloudy_sharp = IoniconsData(0xea61);
 
   /// code
-  static const IconData code = IoniconsData(0xea62);
+  static const IconData? code = IoniconsData(0xea62);
 
   /// code-download
-  static const IconData code_download = IoniconsData(0xea63);
+  static const IconData? code_download = IoniconsData(0xea63);
 
   /// code-download-outline
-  static const IconData code_download_outline = IoniconsData(0xea64);
+  static const IconData? code_download_outline = IoniconsData(0xea64);
 
   /// code-download-sharp
-  static const IconData code_download_sharp = IoniconsData(0xea65);
+  static const IconData? code_download_sharp = IoniconsData(0xea65);
 
   /// code-outline
-  static const IconData code_outline = IoniconsData(0xea66);
+  static const IconData? code_outline = IoniconsData(0xea66);
 
   /// code-sharp
-  static const IconData code_sharp = IoniconsData(0xea67);
+  static const IconData? code_sharp = IoniconsData(0xea67);
 
   /// code-slash
-  static const IconData code_slash = IoniconsData(0xea68);
+  static const IconData? code_slash = IoniconsData(0xea68);
 
   /// code-slash-outline
-  static const IconData code_slash_outline = IoniconsData(0xea69);
+  static const IconData? code_slash_outline = IoniconsData(0xea69);
 
   /// code-slash-sharp
-  static const IconData code_slash_sharp = IoniconsData(0xea6a);
+  static const IconData? code_slash_sharp = IoniconsData(0xea6a);
 
   /// code-working
-  static const IconData code_working = IoniconsData(0xea6b);
+  static const IconData? code_working = IoniconsData(0xea6b);
 
   /// code-working-outline
-  static const IconData code_working_outline = IoniconsData(0xea6c);
+  static const IconData? code_working_outline = IoniconsData(0xea6c);
 
   /// code-working-sharp
-  static const IconData code_working_sharp = IoniconsData(0xea6d);
+  static const IconData? code_working_sharp = IoniconsData(0xea6d);
 
   /// cog
-  static const IconData cog = IoniconsData(0xea6e);
+  static const IconData? cog = IoniconsData(0xea6e);
 
   /// cog-outline
-  static const IconData cog_outline = IoniconsData(0xea6f);
+  static const IconData? cog_outline = IoniconsData(0xea6f);
 
   /// cog-sharp
-  static const IconData cog_sharp = IoniconsData(0xea70);
+  static const IconData? cog_sharp = IoniconsData(0xea70);
 
   /// color-fill
-  static const IconData color_fill = IoniconsData(0xea71);
+  static const IconData? color_fill = IoniconsData(0xea71);
 
   /// color-fill-outline
-  static const IconData color_fill_outline = IoniconsData(0xea72);
+  static const IconData? color_fill_outline = IoniconsData(0xea72);
 
   /// color-fill-sharp
-  static const IconData color_fill_sharp = IoniconsData(0xea73);
+  static const IconData? color_fill_sharp = IoniconsData(0xea73);
 
   /// color-filter
-  static const IconData color_filter = IoniconsData(0xea74);
+  static const IconData? color_filter = IoniconsData(0xea74);
 
   /// color-filter-outline
-  static const IconData color_filter_outline = IoniconsData(0xea75);
+  static const IconData? color_filter_outline = IoniconsData(0xea75);
 
   /// color-filter-sharp
-  static const IconData color_filter_sharp = IoniconsData(0xea76);
+  static const IconData? color_filter_sharp = IoniconsData(0xea76);
 
   /// color-palette
-  static const IconData color_palette = IoniconsData(0xea77);
+  static const IconData? color_palette = IoniconsData(0xea77);
 
   /// color-palette-outline
-  static const IconData color_palette_outline = IoniconsData(0xea78);
+  static const IconData? color_palette_outline = IoniconsData(0xea78);
 
   /// color-palette-sharp
-  static const IconData color_palette_sharp = IoniconsData(0xea79);
+  static const IconData? color_palette_sharp = IoniconsData(0xea79);
 
   /// color-wand
-  static const IconData color_wand = IoniconsData(0xea7a);
+  static const IconData? color_wand = IoniconsData(0xea7a);
 
   /// color-wand-outline
-  static const IconData color_wand_outline = IoniconsData(0xea7b);
+  static const IconData? color_wand_outline = IoniconsData(0xea7b);
 
   /// color-wand-sharp
-  static const IconData color_wand_sharp = IoniconsData(0xea7c);
+  static const IconData? color_wand_sharp = IoniconsData(0xea7c);
 
   /// compass
-  static const IconData compass = IoniconsData(0xea7d);
+  static const IconData? compass = IoniconsData(0xea7d);
 
   /// compass-outline
-  static const IconData compass_outline = IoniconsData(0xea7e);
+  static const IconData? compass_outline = IoniconsData(0xea7e);
 
   /// compass-sharp
-  static const IconData compass_sharp = IoniconsData(0xea7f);
+  static const IconData? compass_sharp = IoniconsData(0xea7f);
 
   /// construct
-  static const IconData construct = IoniconsData(0xea80);
+  static const IconData? construct = IoniconsData(0xea80);
 
   /// construct-outline
-  static const IconData construct_outline = IoniconsData(0xea81);
+  static const IconData? construct_outline = IoniconsData(0xea81);
 
   /// construct-sharp
-  static const IconData construct_sharp = IoniconsData(0xea82);
+  static const IconData? construct_sharp = IoniconsData(0xea82);
 
   /// contract
-  static const IconData contract = IoniconsData(0xea83);
+  static const IconData? contract = IoniconsData(0xea83);
 
   /// contract-outline
-  static const IconData contract_outline = IoniconsData(0xea84);
+  static const IconData? contract_outline = IoniconsData(0xea84);
 
   /// contract-sharp
-  static const IconData contract_sharp = IoniconsData(0xea85);
+  static const IconData? contract_sharp = IoniconsData(0xea85);
 
   /// contrast
-  static const IconData contrast = IoniconsData(0xea86);
+  static const IconData? contrast = IoniconsData(0xea86);
 
   /// contrast-outline
-  static const IconData contrast_outline = IoniconsData(0xea87);
+  static const IconData? contrast_outline = IoniconsData(0xea87);
 
   /// contrast-sharp
-  static const IconData contrast_sharp = IoniconsData(0xea88);
+  static const IconData? contrast_sharp = IoniconsData(0xea88);
 
   /// copy
-  static const IconData copy = IoniconsData(0xea89);
+  static const IconData? copy = IoniconsData(0xea89);
 
   /// copy-outline
-  static const IconData copy_outline = IoniconsData(0xea8a);
+  static const IconData? copy_outline = IoniconsData(0xea8a);
 
   /// copy-sharp
-  static const IconData copy_sharp = IoniconsData(0xea8b);
+  static const IconData? copy_sharp = IoniconsData(0xea8b);
 
   /// create
-  static const IconData create = IoniconsData(0xea8c);
+  static const IconData? create = IoniconsData(0xea8c);
 
   /// create-outline
-  static const IconData create_outline = IoniconsData(0xea8d);
+  static const IconData? create_outline = IoniconsData(0xea8d);
 
   /// create-sharp
-  static const IconData create_sharp = IoniconsData(0xea8e);
+  static const IconData? create_sharp = IoniconsData(0xea8e);
 
   /// crop
-  static const IconData crop = IoniconsData(0xea8f);
+  static const IconData? crop = IoniconsData(0xea8f);
 
   /// crop-outline
-  static const IconData crop_outline = IoniconsData(0xea90);
+  static const IconData? crop_outline = IoniconsData(0xea90);
 
   /// crop-sharp
-  static const IconData crop_sharp = IoniconsData(0xea91);
+  static const IconData? crop_sharp = IoniconsData(0xea91);
 
   /// cube
-  static const IconData cube = IoniconsData(0xea92);
+  static const IconData? cube = IoniconsData(0xea92);
 
   /// cube-outline
-  static const IconData cube_outline = IoniconsData(0xea93);
+  static const IconData? cube_outline = IoniconsData(0xea93);
 
   /// cube-sharp
-  static const IconData cube_sharp = IoniconsData(0xea94);
+  static const IconData? cube_sharp = IoniconsData(0xea94);
 
   /// cut
-  static const IconData cut = IoniconsData(0xea95);
+  static const IconData? cut = IoniconsData(0xea95);
 
   /// cut-outline
-  static const IconData cut_outline = IoniconsData(0xea96);
+  static const IconData? cut_outline = IoniconsData(0xea96);
 
   /// cut-sharp
-  static const IconData cut_sharp = IoniconsData(0xea97);
+  static const IconData? cut_sharp = IoniconsData(0xea97);
 
   /// desktop
-  static const IconData desktop = IoniconsData(0xea98);
+  static const IconData? desktop = IoniconsData(0xea98);
 
   /// desktop-outline
-  static const IconData desktop_outline = IoniconsData(0xea99);
+  static const IconData? desktop_outline = IoniconsData(0xea99);
 
   /// desktop-sharp
-  static const IconData desktop_sharp = IoniconsData(0xea9a);
+  static const IconData? desktop_sharp = IoniconsData(0xea9a);
 
   /// diamond
-  static const IconData diamond = IoniconsData(0xea9b);
+  static const IconData? diamond = IoniconsData(0xea9b);
 
   /// diamond-outline
-  static const IconData diamond_outline = IoniconsData(0xea9c);
+  static const IconData? diamond_outline = IoniconsData(0xea9c);
 
   /// diamond-sharp
-  static const IconData diamond_sharp = IoniconsData(0xea9d);
+  static const IconData? diamond_sharp = IoniconsData(0xea9d);
 
   /// dice
-  static const IconData dice = IoniconsData(0xea9e);
+  static const IconData? dice = IoniconsData(0xea9e);
 
   /// dice-outline
-  static const IconData dice_outline = IoniconsData(0xea9f);
+  static const IconData? dice_outline = IoniconsData(0xea9f);
 
   /// dice-sharp
-  static const IconData dice_sharp = IoniconsData(0xeaa0);
+  static const IconData? dice_sharp = IoniconsData(0xeaa0);
 
   /// disc
-  static const IconData disc = IoniconsData(0xeaa1);
+  static const IconData? disc = IoniconsData(0xeaa1);
 
   /// disc-outline
-  static const IconData disc_outline = IoniconsData(0xeaa2);
+  static const IconData? disc_outline = IoniconsData(0xeaa2);
 
   /// disc-sharp
-  static const IconData disc_sharp = IoniconsData(0xeaa3);
+  static const IconData? disc_sharp = IoniconsData(0xeaa3);
 
   /// document
-  static const IconData document = IoniconsData(0xeaa4);
+  static const IconData? document = IoniconsData(0xeaa4);
 
   /// document-attach
-  static const IconData document_attach = IoniconsData(0xeaa5);
+  static const IconData? document_attach = IoniconsData(0xeaa5);
 
   /// document-attach-outline
-  static const IconData document_attach_outline = IoniconsData(0xeaa6);
+  static const IconData? document_attach_outline = IoniconsData(0xeaa6);
 
   /// document-attach-sharp
-  static const IconData document_attach_sharp = IoniconsData(0xeaa7);
+  static const IconData? document_attach_sharp = IoniconsData(0xeaa7);
 
   /// document-lock
-  static const IconData document_lock = IoniconsData(0xeaa8);
+  static const IconData? document_lock = IoniconsData(0xeaa8);
 
   /// document-lock-outline
-  static const IconData document_lock_outline = IoniconsData(0xeaa9);
+  static const IconData? document_lock_outline = IoniconsData(0xeaa9);
 
   /// document-lock-sharp
-  static const IconData document_lock_sharp = IoniconsData(0xeaaa);
+  static const IconData? document_lock_sharp = IoniconsData(0xeaaa);
 
   /// document-outline
-  static const IconData document_outline = IoniconsData(0xeaab);
+  static const IconData? document_outline = IoniconsData(0xeaab);
 
   /// documents
-  static const IconData documents = IoniconsData(0xeaac);
+  static const IconData? documents = IoniconsData(0xeaac);
 
   /// document-sharp
-  static const IconData document_sharp = IoniconsData(0xeaad);
+  static const IconData? document_sharp = IoniconsData(0xeaad);
 
   /// documents-outline
-  static const IconData documents_outline = IoniconsData(0xeaae);
+  static const IconData? documents_outline = IoniconsData(0xeaae);
 
   /// documents-sharp
-  static const IconData documents_sharp = IoniconsData(0xeaaf);
+  static const IconData? documents_sharp = IoniconsData(0xeaaf);
 
   /// document-text
-  static const IconData document_text = IoniconsData(0xeab0);
+  static const IconData? document_text = IoniconsData(0xeab0);
 
   /// document-text-outline
-  static const IconData document_text_outline = IoniconsData(0xeab1);
+  static const IconData? document_text_outline = IoniconsData(0xeab1);
 
   /// document-text-sharp
-  static const IconData document_text_sharp = IoniconsData(0xeab2);
+  static const IconData? document_text_sharp = IoniconsData(0xeab2);
 
   /// download
-  static const IconData download = IoniconsData(0xeab3);
+  static const IconData? download = IoniconsData(0xeab3);
 
   /// download-outline
-  static const IconData download_outline = IoniconsData(0xeab4);
+  static const IconData? download_outline = IoniconsData(0xeab4);
 
   /// download-sharp
-  static const IconData download_sharp = IoniconsData(0xeab5);
+  static const IconData? download_sharp = IoniconsData(0xeab5);
 
   /// duplicate
-  static const IconData duplicate = IoniconsData(0xeab6);
+  static const IconData? duplicate = IoniconsData(0xeab6);
 
   /// duplicate-outline
-  static const IconData duplicate_outline = IoniconsData(0xeab7);
+  static const IconData? duplicate_outline = IoniconsData(0xeab7);
 
   /// duplicate-sharp
-  static const IconData duplicate_sharp = IoniconsData(0xeab8);
+  static const IconData? duplicate_sharp = IoniconsData(0xeab8);
 
   /// ear
-  static const IconData ear = IoniconsData(0xeab9);
+  static const IconData? ear = IoniconsData(0xeab9);
 
   /// ear-outline
-  static const IconData ear_outline = IoniconsData(0xeaba);
+  static const IconData? ear_outline = IoniconsData(0xeaba);
 
   /// ear-sharp
-  static const IconData ear_sharp = IoniconsData(0xeabb);
+  static const IconData? ear_sharp = IoniconsData(0xeabb);
 
   /// earth
-  static const IconData earth = IoniconsData(0xeabc);
+  static const IconData? earth = IoniconsData(0xeabc);
 
   /// earth-outline
-  static const IconData earth_outline = IoniconsData(0xeabd);
+  static const IconData? earth_outline = IoniconsData(0xeabd);
 
   /// earth-sharp
-  static const IconData earth_sharp = IoniconsData(0xeabe);
+  static const IconData? earth_sharp = IoniconsData(0xeabe);
 
   /// easel
-  static const IconData easel = IoniconsData(0xeabf);
+  static const IconData? easel = IoniconsData(0xeabf);
 
   /// easel-outline
-  static const IconData easel_outline = IoniconsData(0xeac0);
+  static const IconData? easel_outline = IoniconsData(0xeac0);
 
   /// easel-sharp
-  static const IconData easel_sharp = IoniconsData(0xeac1);
+  static const IconData? easel_sharp = IoniconsData(0xeac1);
 
   /// egg
-  static const IconData egg = IoniconsData(0xeac2);
+  static const IconData? egg = IoniconsData(0xeac2);
 
   /// egg-outline
-  static const IconData egg_outline = IoniconsData(0xeac3);
+  static const IconData? egg_outline = IoniconsData(0xeac3);
 
   /// egg-sharp
-  static const IconData egg_sharp = IoniconsData(0xeac4);
+  static const IconData? egg_sharp = IoniconsData(0xeac4);
 
   /// ellipse
-  static const IconData ellipse = IoniconsData(0xeac5);
+  static const IconData? ellipse = IoniconsData(0xeac5);
 
   /// ellipse-outline
-  static const IconData ellipse_outline = IoniconsData(0xeac6);
+  static const IconData? ellipse_outline = IoniconsData(0xeac6);
 
   /// ellipse-sharp
-  static const IconData ellipse_sharp = IoniconsData(0xeac7);
+  static const IconData? ellipse_sharp = IoniconsData(0xeac7);
 
   /// ellipsis-horizontal
-  static const IconData ellipsis_horizontal = IoniconsData(0xeac8);
+  static const IconData? ellipsis_horizontal = IoniconsData(0xeac8);
 
   /// ellipsis-horizontal-circle
-  static const IconData ellipsis_horizontal_circle = IoniconsData(0xeac9);
+  static const IconData? ellipsis_horizontal_circle = IoniconsData(0xeac9);
 
   /// ellipsis-horizontal-circle-outline
-  static const IconData ellipsis_horizontal_circle_outline =
+  static const IconData? ellipsis_horizontal_circle_outline =
       IoniconsData(0xeaca);
 
   /// ellipsis-horizontal-circle-sharp
-  static const IconData ellipsis_horizontal_circle_sharp = IoniconsData(0xeacb);
+  static const IconData? ellipsis_horizontal_circle_sharp = IoniconsData(0xeacb);
 
   /// ellipsis-horizontal-outline
-  static const IconData ellipsis_horizontal_outline = IoniconsData(0xeacc);
+  static const IconData? ellipsis_horizontal_outline = IoniconsData(0xeacc);
 
   /// ellipsis-horizontal-sharp
-  static const IconData ellipsis_horizontal_sharp = IoniconsData(0xeacd);
+  static const IconData? ellipsis_horizontal_sharp = IoniconsData(0xeacd);
 
   /// ellipsis-vertical
-  static const IconData ellipsis_vertical = IoniconsData(0xeace);
+  static const IconData? ellipsis_vertical = IoniconsData(0xeace);
 
   /// ellipsis-vertical-circle
-  static const IconData ellipsis_vertical_circle = IoniconsData(0xeacf);
+  static const IconData? ellipsis_vertical_circle = IoniconsData(0xeacf);
 
   /// ellipsis-vertical-circle-outline
-  static const IconData ellipsis_vertical_circle_outline = IoniconsData(0xead0);
+  static const IconData? ellipsis_vertical_circle_outline = IoniconsData(0xead0);
 
   /// ellipsis-vertical-circle-sharp
-  static const IconData ellipsis_vertical_circle_sharp = IoniconsData(0xead1);
+  static const IconData? ellipsis_vertical_circle_sharp = IoniconsData(0xead1);
 
   /// ellipsis-vertical-outline
-  static const IconData ellipsis_vertical_outline = IoniconsData(0xead2);
+  static const IconData? ellipsis_vertical_outline = IoniconsData(0xead2);
 
   /// ellipsis-vertical-sharp
-  static const IconData ellipsis_vertical_sharp = IoniconsData(0xead3);
+  static const IconData? ellipsis_vertical_sharp = IoniconsData(0xead3);
 
   /// enter
-  static const IconData enter = IoniconsData(0xead4);
+  static const IconData? enter = IoniconsData(0xead4);
 
   /// enter-outline
-  static const IconData enter_outline = IoniconsData(0xead5);
+  static const IconData? enter_outline = IoniconsData(0xead5);
 
   /// enter-sharp
-  static const IconData enter_sharp = IoniconsData(0xead6);
+  static const IconData? enter_sharp = IoniconsData(0xead6);
 
   /// exit
-  static const IconData exit = IoniconsData(0xead7);
+  static const IconData? exit = IoniconsData(0xead7);
 
   /// exit-outline
-  static const IconData exit_outline = IoniconsData(0xead8);
+  static const IconData? exit_outline = IoniconsData(0xead8);
 
   /// exit-sharp
-  static const IconData exit_sharp = IoniconsData(0xead9);
+  static const IconData? exit_sharp = IoniconsData(0xead9);
 
   /// expand
-  static const IconData expand = IoniconsData(0xeada);
+  static const IconData? expand = IoniconsData(0xeada);
 
   /// expand-outline
-  static const IconData expand_outline = IoniconsData(0xeadb);
+  static const IconData? expand_outline = IoniconsData(0xeadb);
 
   /// expand-sharp
-  static const IconData expand_sharp = IoniconsData(0xeadc);
+  static const IconData? expand_sharp = IoniconsData(0xeadc);
 
   /// extension-puzzle
-  static const IconData extension_puzzle = IoniconsData(0xeadd);
+  static const IconData? extension_puzzle = IoniconsData(0xeadd);
 
   /// extension-puzzle-outline
-  static const IconData extension_puzzle_outline = IoniconsData(0xeade);
+  static const IconData? extension_puzzle_outline = IoniconsData(0xeade);
 
   /// extension-puzzle-sharp
-  static const IconData extension_puzzle_sharp = IoniconsData(0xeadf);
+  static const IconData? extension_puzzle_sharp = IoniconsData(0xeadf);
 
   /// eye
-  static const IconData eye = IoniconsData(0xeae0);
+  static const IconData? eye = IoniconsData(0xeae0);
 
   /// eyedrop
-  static const IconData eyedrop = IoniconsData(0xeae1);
+  static const IconData? eyedrop = IoniconsData(0xeae1);
 
   /// eyedrop-outline
-  static const IconData eyedrop_outline = IoniconsData(0xeae2);
+  static const IconData? eyedrop_outline = IoniconsData(0xeae2);
 
   /// eyedrop-sharp
-  static const IconData eyedrop_sharp = IoniconsData(0xeae3);
+  static const IconData? eyedrop_sharp = IoniconsData(0xeae3);
 
   /// eye-off
-  static const IconData eye_off = IoniconsData(0xeae4);
+  static const IconData? eye_off = IoniconsData(0xeae4);
 
   /// eye-off-outline
-  static const IconData eye_off_outline = IoniconsData(0xeae5);
+  static const IconData? eye_off_outline = IoniconsData(0xeae5);
 
   /// eye-off-sharp
-  static const IconData eye_off_sharp = IoniconsData(0xeae6);
+  static const IconData? eye_off_sharp = IoniconsData(0xeae6);
 
   /// eye-outline
-  static const IconData eye_outline = IoniconsData(0xeae7);
+  static const IconData? eye_outline = IoniconsData(0xeae7);
 
   /// eye-sharp
-  static const IconData eye_sharp = IoniconsData(0xeae8);
+  static const IconData? eye_sharp = IoniconsData(0xeae8);
 
   /// fast-food
-  static const IconData fast_food = IoniconsData(0xeae9);
+  static const IconData? fast_food = IoniconsData(0xeae9);
 
   /// fast-food-outline
-  static const IconData fast_food_outline = IoniconsData(0xeaea);
+  static const IconData? fast_food_outline = IoniconsData(0xeaea);
 
   /// fast-food-sharp
-  static const IconData fast_food_sharp = IoniconsData(0xeaeb);
+  static const IconData? fast_food_sharp = IoniconsData(0xeaeb);
 
   /// female
-  static const IconData female = IoniconsData(0xeaec);
+  static const IconData? female = IoniconsData(0xeaec);
 
   /// female-outline
-  static const IconData female_outline = IoniconsData(0xeaed);
+  static const IconData? female_outline = IoniconsData(0xeaed);
 
   /// female-sharp
-  static const IconData female_sharp = IoniconsData(0xeaee);
+  static const IconData? female_sharp = IoniconsData(0xeaee);
 
   /// file-tray
-  static const IconData file_tray = IoniconsData(0xeaef);
+  static const IconData? file_tray = IoniconsData(0xeaef);
 
   /// file-tray-full
-  static const IconData file_tray_full = IoniconsData(0xeaf0);
+  static const IconData? file_tray_full = IoniconsData(0xeaf0);
 
   /// file-tray-full-outline
-  static const IconData file_tray_full_outline = IoniconsData(0xeaf1);
+  static const IconData? file_tray_full_outline = IoniconsData(0xeaf1);
 
   /// file-tray-full-sharp
-  static const IconData file_tray_full_sharp = IoniconsData(0xeaf2);
+  static const IconData? file_tray_full_sharp = IoniconsData(0xeaf2);
 
   /// file-tray-outline
-  static const IconData file_tray_outline = IoniconsData(0xeaf3);
+  static const IconData? file_tray_outline = IoniconsData(0xeaf3);
 
   /// file-tray-sharp
-  static const IconData file_tray_sharp = IoniconsData(0xeaf4);
+  static const IconData? file_tray_sharp = IoniconsData(0xeaf4);
 
   /// file-tray-stacked
-  static const IconData file_tray_stacked = IoniconsData(0xeaf5);
+  static const IconData? file_tray_stacked = IoniconsData(0xeaf5);
 
   /// file-tray-stacked-outline
-  static const IconData file_tray_stacked_outline = IoniconsData(0xeaf6);
+  static const IconData? file_tray_stacked_outline = IoniconsData(0xeaf6);
 
   /// file-tray-stacked-sharp
-  static const IconData file_tray_stacked_sharp = IoniconsData(0xeaf7);
+  static const IconData? file_tray_stacked_sharp = IoniconsData(0xeaf7);
 
   /// film
-  static const IconData film = IoniconsData(0xeaf8);
+  static const IconData? film = IoniconsData(0xeaf8);
 
   /// film-outline
-  static const IconData film_outline = IoniconsData(0xeaf9);
+  static const IconData? film_outline = IoniconsData(0xeaf9);
 
   /// film-sharp
-  static const IconData film_sharp = IoniconsData(0xeafa);
+  static const IconData? film_sharp = IoniconsData(0xeafa);
 
   /// filter
-  static const IconData filter = IoniconsData(0xeafb);
+  static const IconData? filter = IoniconsData(0xeafb);
 
   /// filter-circle
-  static const IconData filter_circle = IoniconsData(0xeafc);
+  static const IconData? filter_circle = IoniconsData(0xeafc);
 
   /// filter-circle-outline
-  static const IconData filter_circle_outline = IoniconsData(0xeafd);
+  static const IconData? filter_circle_outline = IoniconsData(0xeafd);
 
   /// filter-circle-sharp
-  static const IconData filter_circle_sharp = IoniconsData(0xeafe);
+  static const IconData? filter_circle_sharp = IoniconsData(0xeafe);
 
   /// filter-outline
-  static const IconData filter_outline = IoniconsData(0xeaff);
+  static const IconData? filter_outline = IoniconsData(0xeaff);
 
   /// filter-sharp
-  static const IconData filter_sharp = IoniconsData(0xeb00);
+  static const IconData? filter_sharp = IoniconsData(0xeb00);
 
   /// finger-print
-  static const IconData finger_print = IoniconsData(0xeb01);
+  static const IconData? finger_print = IoniconsData(0xeb01);
 
   /// finger-print-outline
-  static const IconData finger_print_outline = IoniconsData(0xeb02);
+  static const IconData? finger_print_outline = IoniconsData(0xeb02);
 
   /// finger-print-sharp
-  static const IconData finger_print_sharp = IoniconsData(0xeb03);
+  static const IconData? finger_print_sharp = IoniconsData(0xeb03);
 
   /// fish
-  static const IconData fish = IoniconsData(0xeb04);
+  static const IconData? fish = IoniconsData(0xeb04);
 
   /// fish-outline
-  static const IconData fish_outline = IoniconsData(0xeb05);
+  static const IconData? fish_outline = IoniconsData(0xeb05);
 
   /// fish-sharp
-  static const IconData fish_sharp = IoniconsData(0xeb06);
+  static const IconData? fish_sharp = IoniconsData(0xeb06);
 
   /// fitness
-  static const IconData fitness = IoniconsData(0xeb07);
+  static const IconData? fitness = IoniconsData(0xeb07);
 
   /// fitness-outline
-  static const IconData fitness_outline = IoniconsData(0xeb08);
+  static const IconData? fitness_outline = IoniconsData(0xeb08);
 
   /// fitness-sharp
-  static const IconData fitness_sharp = IoniconsData(0xeb09);
+  static const IconData? fitness_sharp = IoniconsData(0xeb09);
 
   /// flag
-  static const IconData flag = IoniconsData(0xeb0a);
+  static const IconData? flag = IoniconsData(0xeb0a);
 
   /// flag-outline
-  static const IconData flag_outline = IoniconsData(0xeb0b);
+  static const IconData? flag_outline = IoniconsData(0xeb0b);
 
   /// flag-sharp
-  static const IconData flag_sharp = IoniconsData(0xeb0c);
+  static const IconData? flag_sharp = IoniconsData(0xeb0c);
 
   /// flame
-  static const IconData flame = IoniconsData(0xeb0d);
+  static const IconData? flame = IoniconsData(0xeb0d);
 
   /// flame-outline
-  static const IconData flame_outline = IoniconsData(0xeb0e);
+  static const IconData? flame_outline = IoniconsData(0xeb0e);
 
   /// flame-sharp
-  static const IconData flame_sharp = IoniconsData(0xeb0f);
+  static const IconData? flame_sharp = IoniconsData(0xeb0f);
 
   /// flash
-  static const IconData flash = IoniconsData(0xeb10);
+  static const IconData? flash = IoniconsData(0xeb10);
 
   /// flashlight
-  static const IconData flashlight = IoniconsData(0xeb11);
+  static const IconData? flashlight = IoniconsData(0xeb11);
 
   /// flashlight-outline
-  static const IconData flashlight_outline = IoniconsData(0xeb12);
+  static const IconData? flashlight_outline = IoniconsData(0xeb12);
 
   /// flashlight-sharp
-  static const IconData flashlight_sharp = IoniconsData(0xeb13);
+  static const IconData? flashlight_sharp = IoniconsData(0xeb13);
 
   /// flash-off
-  static const IconData flash_off = IoniconsData(0xeb14);
+  static const IconData? flash_off = IoniconsData(0xeb14);
 
   /// flash-off-outline
-  static const IconData flash_off_outline = IoniconsData(0xeb15);
+  static const IconData? flash_off_outline = IoniconsData(0xeb15);
 
   /// flash-off-sharp
-  static const IconData flash_off_sharp = IoniconsData(0xeb16);
+  static const IconData? flash_off_sharp = IoniconsData(0xeb16);
 
   /// flash-outline
-  static const IconData flash_outline = IoniconsData(0xeb17);
+  static const IconData? flash_outline = IoniconsData(0xeb17);
 
   /// flash-sharp
-  static const IconData flash_sharp = IoniconsData(0xeb18);
+  static const IconData? flash_sharp = IoniconsData(0xeb18);
 
   /// flask
-  static const IconData flask = IoniconsData(0xeb19);
+  static const IconData? flask = IoniconsData(0xeb19);
 
   /// flask-outline
-  static const IconData flask_outline = IoniconsData(0xeb1a);
+  static const IconData? flask_outline = IoniconsData(0xeb1a);
 
   /// flask-sharp
-  static const IconData flask_sharp = IoniconsData(0xeb1b);
+  static const IconData? flask_sharp = IoniconsData(0xeb1b);
 
   /// flower
-  static const IconData flower = IoniconsData(0xeb1c);
+  static const IconData? flower = IoniconsData(0xeb1c);
 
   /// flower-outline
-  static const IconData flower_outline = IoniconsData(0xeb1d);
+  static const IconData? flower_outline = IoniconsData(0xeb1d);
 
   /// flower-sharp
-  static const IconData flower_sharp = IoniconsData(0xeb1e);
+  static const IconData? flower_sharp = IoniconsData(0xeb1e);
 
   /// folder
-  static const IconData folder = IoniconsData(0xeb1f);
+  static const IconData? folder = IoniconsData(0xeb1f);
 
   /// folder-open
-  static const IconData folder_open = IoniconsData(0xeb20);
+  static const IconData? folder_open = IoniconsData(0xeb20);
 
   /// folder-open-outline
-  static const IconData folder_open_outline = IoniconsData(0xeb21);
+  static const IconData? folder_open_outline = IoniconsData(0xeb21);
 
   /// folder-open-sharp
-  static const IconData folder_open_sharp = IoniconsData(0xeb22);
+  static const IconData? folder_open_sharp = IoniconsData(0xeb22);
 
   /// folder-outline
-  static const IconData folder_outline = IoniconsData(0xeb23);
+  static const IconData? folder_outline = IoniconsData(0xeb23);
 
   /// folder-sharp
-  static const IconData folder_sharp = IoniconsData(0xeb24);
+  static const IconData? folder_sharp = IoniconsData(0xeb24);
 
   /// football
-  static const IconData football = IoniconsData(0xeb25);
+  static const IconData? football = IoniconsData(0xeb25);
 
   /// football-outline
-  static const IconData football_outline = IoniconsData(0xeb26);
+  static const IconData? football_outline = IoniconsData(0xeb26);
 
   /// football-sharp
-  static const IconData football_sharp = IoniconsData(0xeb27);
+  static const IconData? football_sharp = IoniconsData(0xeb27);
 
   /// footsteps
-  static const IconData footsteps = IoniconsData(0xeb28);
+  static const IconData? footsteps = IoniconsData(0xeb28);
 
   /// footsteps-outline
-  static const IconData footsteps_outline = IoniconsData(0xeb29);
+  static const IconData? footsteps_outline = IoniconsData(0xeb29);
 
   /// footsteps-sharp
-  static const IconData footsteps_sharp = IoniconsData(0xeb2a);
+  static const IconData? footsteps_sharp = IoniconsData(0xeb2a);
 
   /// funnel
-  static const IconData funnel = IoniconsData(0xeb2b);
+  static const IconData? funnel = IoniconsData(0xeb2b);
 
   /// funnel-outline
-  static const IconData funnel_outline = IoniconsData(0xeb2c);
+  static const IconData? funnel_outline = IoniconsData(0xeb2c);
 
   /// funnel-sharp
-  static const IconData funnel_sharp = IoniconsData(0xeb2d);
+  static const IconData? funnel_sharp = IoniconsData(0xeb2d);
 
   /// game-controller
-  static const IconData game_controller = IoniconsData(0xeb2e);
+  static const IconData? game_controller = IoniconsData(0xeb2e);
 
   /// game-controller-outline
-  static const IconData game_controller_outline = IoniconsData(0xeb2f);
+  static const IconData? game_controller_outline = IoniconsData(0xeb2f);
 
   /// game-controller-sharp
-  static const IconData game_controller_sharp = IoniconsData(0xeb30);
+  static const IconData? game_controller_sharp = IoniconsData(0xeb30);
 
   /// gift
-  static const IconData gift = IoniconsData(0xeb31);
+  static const IconData? gift = IoniconsData(0xeb31);
 
   /// gift-outline
-  static const IconData gift_outline = IoniconsData(0xeb32);
+  static const IconData? gift_outline = IoniconsData(0xeb32);
 
   /// gift-sharp
-  static const IconData gift_sharp = IoniconsData(0xeb33);
+  static const IconData? gift_sharp = IoniconsData(0xeb33);
 
   /// git-branch
-  static const IconData git_branch = IoniconsData(0xeb34);
+  static const IconData? git_branch = IoniconsData(0xeb34);
 
   /// git-branch-outline
-  static const IconData git_branch_outline = IoniconsData(0xeb35);
+  static const IconData? git_branch_outline = IoniconsData(0xeb35);
 
   /// git-branch-sharp
-  static const IconData git_branch_sharp = IoniconsData(0xeb36);
+  static const IconData? git_branch_sharp = IoniconsData(0xeb36);
 
   /// git-commit
-  static const IconData git_commit = IoniconsData(0xeb37);
+  static const IconData? git_commit = IoniconsData(0xeb37);
 
   /// git-commit-outline
-  static const IconData git_commit_outline = IoniconsData(0xeb38);
+  static const IconData? git_commit_outline = IoniconsData(0xeb38);
 
   /// git-commit-sharp
-  static const IconData git_commit_sharp = IoniconsData(0xeb39);
+  static const IconData? git_commit_sharp = IoniconsData(0xeb39);
 
   /// git-compare
-  static const IconData git_compare = IoniconsData(0xeb3a);
+  static const IconData? git_compare = IoniconsData(0xeb3a);
 
   /// git-compare-outline
-  static const IconData git_compare_outline = IoniconsData(0xeb3b);
+  static const IconData? git_compare_outline = IoniconsData(0xeb3b);
 
   /// git-compare-sharp
-  static const IconData git_compare_sharp = IoniconsData(0xeb3c);
+  static const IconData? git_compare_sharp = IoniconsData(0xeb3c);
 
   /// git-merge
-  static const IconData git_merge = IoniconsData(0xeb3d);
+  static const IconData? git_merge = IoniconsData(0xeb3d);
 
   /// git-merge-outline
-  static const IconData git_merge_outline = IoniconsData(0xeb3e);
+  static const IconData? git_merge_outline = IoniconsData(0xeb3e);
 
   /// git-merge-sharp
-  static const IconData git_merge_sharp = IoniconsData(0xeb3f);
+  static const IconData? git_merge_sharp = IoniconsData(0xeb3f);
 
   /// git-network
-  static const IconData git_network = IoniconsData(0xeb40);
+  static const IconData? git_network = IoniconsData(0xeb40);
 
   /// git-network-outline
-  static const IconData git_network_outline = IoniconsData(0xeb41);
+  static const IconData? git_network_outline = IoniconsData(0xeb41);
 
   /// git-network-sharp
-  static const IconData git_network_sharp = IoniconsData(0xeb42);
+  static const IconData? git_network_sharp = IoniconsData(0xeb42);
 
   /// git-pull-request
-  static const IconData git_pull_request = IoniconsData(0xeb43);
+  static const IconData? git_pull_request = IoniconsData(0xeb43);
 
   /// git-pull-request-outline
-  static const IconData git_pull_request_outline = IoniconsData(0xeb44);
+  static const IconData? git_pull_request_outline = IoniconsData(0xeb44);
 
   /// git-pull-request-sharp
-  static const IconData git_pull_request_sharp = IoniconsData(0xeb45);
+  static const IconData? git_pull_request_sharp = IoniconsData(0xeb45);
 
   /// glasses
-  static const IconData glasses = IoniconsData(0xeb46);
+  static const IconData? glasses = IoniconsData(0xeb46);
 
   /// glasses-outline
-  static const IconData glasses_outline = IoniconsData(0xeb47);
+  static const IconData? glasses_outline = IoniconsData(0xeb47);
 
   /// glasses-sharp
-  static const IconData glasses_sharp = IoniconsData(0xeb48);
+  static const IconData? glasses_sharp = IoniconsData(0xeb48);
 
   /// globe
-  static const IconData globe = IoniconsData(0xeb49);
+  static const IconData? globe = IoniconsData(0xeb49);
 
   /// globe-outline
-  static const IconData globe_outline = IoniconsData(0xeb4a);
+  static const IconData? globe_outline = IoniconsData(0xeb4a);
 
   /// globe-sharp
-  static const IconData globe_sharp = IoniconsData(0xeb4b);
+  static const IconData? globe_sharp = IoniconsData(0xeb4b);
 
   /// golf
-  static const IconData golf = IoniconsData(0xeb4c);
+  static const IconData? golf = IoniconsData(0xeb4c);
 
   /// golf-outline
-  static const IconData golf_outline = IoniconsData(0xeb4d);
+  static const IconData? golf_outline = IoniconsData(0xeb4d);
 
   /// golf-sharp
-  static const IconData golf_sharp = IoniconsData(0xeb4e);
+  static const IconData? golf_sharp = IoniconsData(0xeb4e);
 
   /// grid
-  static const IconData grid = IoniconsData(0xeb4f);
+  static const IconData? grid = IoniconsData(0xeb4f);
 
   /// grid-outline
-  static const IconData grid_outline = IoniconsData(0xeb50);
+  static const IconData? grid_outline = IoniconsData(0xeb50);
 
   /// grid-sharp
-  static const IconData grid_sharp = IoniconsData(0xeb51);
+  static const IconData? grid_sharp = IoniconsData(0xeb51);
 
   /// hammer
-  static const IconData hammer = IoniconsData(0xeb52);
+  static const IconData? hammer = IoniconsData(0xeb52);
 
   /// hammer-outline
-  static const IconData hammer_outline = IoniconsData(0xeb53);
+  static const IconData? hammer_outline = IoniconsData(0xeb53);
 
   /// hammer-sharp
-  static const IconData hammer_sharp = IoniconsData(0xeb54);
+  static const IconData? hammer_sharp = IoniconsData(0xeb54);
 
   /// hand-left
-  static const IconData hand_left = IoniconsData(0xeb55);
+  static const IconData? hand_left = IoniconsData(0xeb55);
 
   /// hand-left-outline
-  static const IconData hand_left_outline = IoniconsData(0xeb56);
+  static const IconData? hand_left_outline = IoniconsData(0xeb56);
 
   /// hand-left-sharp
-  static const IconData hand_left_sharp = IoniconsData(0xeb57);
+  static const IconData? hand_left_sharp = IoniconsData(0xeb57);
 
   /// hand-right
-  static const IconData hand_right = IoniconsData(0xeb58);
+  static const IconData? hand_right = IoniconsData(0xeb58);
 
   /// hand-right-outline
-  static const IconData hand_right_outline = IoniconsData(0xeb59);
+  static const IconData? hand_right_outline = IoniconsData(0xeb59);
 
   /// hand-right-sharp
-  static const IconData hand_right_sharp = IoniconsData(0xeb5a);
+  static const IconData? hand_right_sharp = IoniconsData(0xeb5a);
 
   /// happy
-  static const IconData happy = IoniconsData(0xeb5b);
+  static const IconData? happy = IoniconsData(0xeb5b);
 
   /// happy-outline
-  static const IconData happy_outline = IoniconsData(0xeb5c);
+  static const IconData? happy_outline = IoniconsData(0xeb5c);
 
   /// happy-sharp
-  static const IconData happy_sharp = IoniconsData(0xeb5d);
+  static const IconData? happy_sharp = IoniconsData(0xeb5d);
 
   /// hardware-chip
-  static const IconData hardware_chip = IoniconsData(0xeb5e);
+  static const IconData? hardware_chip = IoniconsData(0xeb5e);
 
   /// hardware-chip-outline
-  static const IconData hardware_chip_outline = IoniconsData(0xeb5f);
+  static const IconData? hardware_chip_outline = IoniconsData(0xeb5f);
 
   /// hardware-chip-sharp
-  static const IconData hardware_chip_sharp = IoniconsData(0xeb60);
+  static const IconData? hardware_chip_sharp = IoniconsData(0xeb60);
 
   /// headset
-  static const IconData headset = IoniconsData(0xeb61);
+  static const IconData? headset = IoniconsData(0xeb61);
 
   /// headset-outline
-  static const IconData headset_outline = IoniconsData(0xeb62);
+  static const IconData? headset_outline = IoniconsData(0xeb62);
 
   /// headset-sharp
-  static const IconData headset_sharp = IoniconsData(0xeb63);
+  static const IconData? headset_sharp = IoniconsData(0xeb63);
 
   /// heart
-  static const IconData heart = IoniconsData(0xeb64);
+  static const IconData? heart = IoniconsData(0xeb64);
 
   /// heart-circle
-  static const IconData heart_circle = IoniconsData(0xeb65);
+  static const IconData? heart_circle = IoniconsData(0xeb65);
 
   /// heart-circle-outline
-  static const IconData heart_circle_outline = IoniconsData(0xeb66);
+  static const IconData? heart_circle_outline = IoniconsData(0xeb66);
 
   /// heart-circle-sharp
-  static const IconData heart_circle_sharp = IoniconsData(0xeb67);
+  static const IconData? heart_circle_sharp = IoniconsData(0xeb67);
 
   /// heart-dislike
-  static const IconData heart_dislike = IoniconsData(0xeb68);
+  static const IconData? heart_dislike = IoniconsData(0xeb68);
 
   /// heart-dislike-circle
-  static const IconData heart_dislike_circle = IoniconsData(0xeb69);
+  static const IconData? heart_dislike_circle = IoniconsData(0xeb69);
 
   /// heart-dislike-circle-outline
-  static const IconData heart_dislike_circle_outline = IoniconsData(0xeb6a);
+  static const IconData? heart_dislike_circle_outline = IoniconsData(0xeb6a);
 
   /// heart-dislike-circle-sharp
-  static const IconData heart_dislike_circle_sharp = IoniconsData(0xeb6b);
+  static const IconData? heart_dislike_circle_sharp = IoniconsData(0xeb6b);
 
   /// heart-dislike-outline
-  static const IconData heart_dislike_outline = IoniconsData(0xeb6c);
+  static const IconData? heart_dislike_outline = IoniconsData(0xeb6c);
 
   /// heart-dislike-sharp
-  static const IconData heart_dislike_sharp = IoniconsData(0xeb6d);
+  static const IconData? heart_dislike_sharp = IoniconsData(0xeb6d);
 
   /// heart-half
-  static const IconData heart_half = IoniconsData(0xeb6e);
+  static const IconData? heart_half = IoniconsData(0xeb6e);
 
   /// heart-half-outline
-  static const IconData heart_half_outline = IoniconsData(0xeb6f);
+  static const IconData? heart_half_outline = IoniconsData(0xeb6f);
 
   /// heart-half-sharp
-  static const IconData heart_half_sharp = IoniconsData(0xeb70);
+  static const IconData? heart_half_sharp = IoniconsData(0xeb70);
 
   /// heart-outline
-  static const IconData heart_outline = IoniconsData(0xeb71);
+  static const IconData? heart_outline = IoniconsData(0xeb71);
 
   /// heart-sharp
-  static const IconData heart_sharp = IoniconsData(0xeb72);
+  static const IconData? heart_sharp = IoniconsData(0xeb72);
 
   /// help
-  static const IconData help = IoniconsData(0xeb73);
+  static const IconData? help = IoniconsData(0xeb73);
 
   /// help-buoy
-  static const IconData help_buoy = IoniconsData(0xeb74);
+  static const IconData? help_buoy = IoniconsData(0xeb74);
 
   /// help-buoy-outline
-  static const IconData help_buoy_outline = IoniconsData(0xeb75);
+  static const IconData? help_buoy_outline = IoniconsData(0xeb75);
 
   /// help-buoy-sharp
-  static const IconData help_buoy_sharp = IoniconsData(0xeb76);
+  static const IconData? help_buoy_sharp = IoniconsData(0xeb76);
 
   /// help-circle
-  static const IconData help_circle = IoniconsData(0xeb77);
+  static const IconData? help_circle = IoniconsData(0xeb77);
 
   /// help-circle-outline
-  static const IconData help_circle_outline = IoniconsData(0xeb78);
+  static const IconData? help_circle_outline = IoniconsData(0xeb78);
 
   /// help-circle-sharp
-  static const IconData help_circle_sharp = IoniconsData(0xeb79);
+  static const IconData? help_circle_sharp = IoniconsData(0xeb79);
 
   /// help-outline
-  static const IconData help_outline = IoniconsData(0xeb7a);
+  static const IconData? help_outline = IoniconsData(0xeb7a);
 
   /// help-sharp
-  static const IconData help_sharp = IoniconsData(0xeb7b);
+  static const IconData? help_sharp = IoniconsData(0xeb7b);
 
   /// home
-  static const IconData home = IoniconsData(0xeb7c);
+  static const IconData? home = IoniconsData(0xeb7c);
 
   /// home-outline
-  static const IconData home_outline = IoniconsData(0xeb7d);
+  static const IconData? home_outline = IoniconsData(0xeb7d);
 
   /// home-sharp
-  static const IconData home_sharp = IoniconsData(0xeb7e);
+  static const IconData? home_sharp = IoniconsData(0xeb7e);
 
   /// hourglass
-  static const IconData hourglass = IoniconsData(0xeb7f);
+  static const IconData? hourglass = IoniconsData(0xeb7f);
 
   /// hourglass-outline
-  static const IconData hourglass_outline = IoniconsData(0xeb80);
+  static const IconData? hourglass_outline = IoniconsData(0xeb80);
 
   /// hourglass-sharp
-  static const IconData hourglass_sharp = IoniconsData(0xeb81);
+  static const IconData? hourglass_sharp = IoniconsData(0xeb81);
 
   /// ice-cream
-  static const IconData ice_cream = IoniconsData(0xeb82);
+  static const IconData? ice_cream = IoniconsData(0xeb82);
 
   /// ice-cream-outline
-  static const IconData ice_cream_outline = IoniconsData(0xeb83);
+  static const IconData? ice_cream_outline = IoniconsData(0xeb83);
 
   /// ice-cream-sharp
-  static const IconData ice_cream_sharp = IoniconsData(0xeb84);
+  static const IconData? ice_cream_sharp = IoniconsData(0xeb84);
 
   /// id-card
-  static const IconData id_card = IoniconsData(0xeb85);
+  static const IconData? id_card = IoniconsData(0xeb85);
 
   /// id-card-outline
-  static const IconData id_card_outline = IoniconsData(0xeb86);
+  static const IconData? id_card_outline = IoniconsData(0xeb86);
 
   /// id-card-sharp
-  static const IconData id_card_sharp = IoniconsData(0xeb87);
+  static const IconData? id_card_sharp = IoniconsData(0xeb87);
 
   /// image
-  static const IconData image = IoniconsData(0xeb88);
+  static const IconData? image = IoniconsData(0xeb88);
 
   /// image-outline
-  static const IconData image_outline = IoniconsData(0xeb89);
+  static const IconData? image_outline = IoniconsData(0xeb89);
 
   /// images
-  static const IconData images = IoniconsData(0xeb8a);
+  static const IconData? images = IoniconsData(0xeb8a);
 
   /// image-sharp
-  static const IconData image_sharp = IoniconsData(0xeb8b);
+  static const IconData? image_sharp = IoniconsData(0xeb8b);
 
   /// images-outline
-  static const IconData images_outline = IoniconsData(0xeb8c);
+  static const IconData? images_outline = IoniconsData(0xeb8c);
 
   /// images-sharp
-  static const IconData images_sharp = IoniconsData(0xeb8d);
+  static const IconData? images_sharp = IoniconsData(0xeb8d);
 
   /// infinite
-  static const IconData infinite = IoniconsData(0xeb8e);
+  static const IconData? infinite = IoniconsData(0xeb8e);
 
   /// infinite-outline
-  static const IconData infinite_outline = IoniconsData(0xeb8f);
+  static const IconData? infinite_outline = IoniconsData(0xeb8f);
 
   /// infinite-sharp
-  static const IconData infinite_sharp = IoniconsData(0xeb90);
+  static const IconData? infinite_sharp = IoniconsData(0xeb90);
 
   /// information
-  static const IconData information = IoniconsData(0xeb91);
+  static const IconData? information = IoniconsData(0xeb91);
 
   /// information-circle
-  static const IconData information_circle = IoniconsData(0xeb92);
+  static const IconData? information_circle = IoniconsData(0xeb92);
 
   /// information-circle-outline
-  static const IconData information_circle_outline = IoniconsData(0xeb93);
+  static const IconData? information_circle_outline = IoniconsData(0xeb93);
 
   /// information-circle-sharp
-  static const IconData information_circle_sharp = IoniconsData(0xeb94);
+  static const IconData? information_circle_sharp = IoniconsData(0xeb94);
 
   /// information-outline
-  static const IconData information_outline = IoniconsData(0xeb95);
+  static const IconData? information_outline = IoniconsData(0xeb95);
 
   /// information-sharp
-  static const IconData information_sharp = IoniconsData(0xeb96);
+  static const IconData? information_sharp = IoniconsData(0xeb96);
 
   /// invert-mode
-  static const IconData invert_mode = IoniconsData(0xeb97);
+  static const IconData? invert_mode = IoniconsData(0xeb97);
 
   /// invert-mode-outline
-  static const IconData invert_mode_outline = IoniconsData(0xeb98);
+  static const IconData? invert_mode_outline = IoniconsData(0xeb98);
 
   /// invert-mode-sharp
-  static const IconData invert_mode_sharp = IoniconsData(0xeb99);
+  static const IconData? invert_mode_sharp = IoniconsData(0xeb99);
 
   /// journal
-  static const IconData journal = IoniconsData(0xeb9a);
+  static const IconData? journal = IoniconsData(0xeb9a);
 
   /// journal-outline
-  static const IconData journal_outline = IoniconsData(0xeb9b);
+  static const IconData? journal_outline = IoniconsData(0xeb9b);
 
   /// journal-sharp
-  static const IconData journal_sharp = IoniconsData(0xeb9c);
+  static const IconData? journal_sharp = IoniconsData(0xeb9c);
 
   /// key
-  static const IconData key = IoniconsData(0xeb9d);
+  static const IconData? key = IoniconsData(0xeb9d);
 
   /// key-outline
-  static const IconData key_outline = IoniconsData(0xeb9e);
+  static const IconData? key_outline = IoniconsData(0xeb9e);
 
   /// keypad
-  static const IconData keypad = IoniconsData(0xeb9f);
+  static const IconData? keypad = IoniconsData(0xeb9f);
 
   /// keypad-outline
-  static const IconData keypad_outline = IoniconsData(0xeba0);
+  static const IconData? keypad_outline = IoniconsData(0xeba0);
 
   /// keypad-sharp
-  static const IconData keypad_sharp = IoniconsData(0xeba1);
+  static const IconData? keypad_sharp = IoniconsData(0xeba1);
 
   /// key-sharp
-  static const IconData key_sharp = IoniconsData(0xeba2);
+  static const IconData? key_sharp = IoniconsData(0xeba2);
 
   /// language
-  static const IconData language = IoniconsData(0xeba3);
+  static const IconData? language = IoniconsData(0xeba3);
 
   /// language-outline
-  static const IconData language_outline = IoniconsData(0xeba4);
+  static const IconData? language_outline = IoniconsData(0xeba4);
 
   /// language-sharp
-  static const IconData language_sharp = IoniconsData(0xeba5);
+  static const IconData? language_sharp = IoniconsData(0xeba5);
 
   /// laptop
-  static const IconData laptop = IoniconsData(0xeba6);
+  static const IconData? laptop = IoniconsData(0xeba6);
 
   /// laptop-outline
-  static const IconData laptop_outline = IoniconsData(0xeba7);
+  static const IconData? laptop_outline = IoniconsData(0xeba7);
 
   /// laptop-sharp
-  static const IconData laptop_sharp = IoniconsData(0xeba8);
+  static const IconData? laptop_sharp = IoniconsData(0xeba8);
 
   /// layers
-  static const IconData layers = IoniconsData(0xeba9);
+  static const IconData? layers = IoniconsData(0xeba9);
 
   /// layers-outline
-  static const IconData layers_outline = IoniconsData(0xebaa);
+  static const IconData? layers_outline = IoniconsData(0xebaa);
 
   /// layers-sharp
-  static const IconData layers_sharp = IoniconsData(0xebab);
+  static const IconData? layers_sharp = IoniconsData(0xebab);
 
   /// leaf
-  static const IconData leaf = IoniconsData(0xebac);
+  static const IconData? leaf = IoniconsData(0xebac);
 
   /// leaf-outline
-  static const IconData leaf_outline = IoniconsData(0xebad);
+  static const IconData? leaf_outline = IoniconsData(0xebad);
 
   /// leaf-sharp
-  static const IconData leaf_sharp = IoniconsData(0xebae);
+  static const IconData? leaf_sharp = IoniconsData(0xebae);
 
   /// library
-  static const IconData library = IoniconsData(0xebaf);
+  static const IconData? library = IoniconsData(0xebaf);
 
   /// library-outline
-  static const IconData library_outline = IoniconsData(0xebb0);
+  static const IconData? library_outline = IoniconsData(0xebb0);
 
   /// library-sharp
-  static const IconData library_sharp = IoniconsData(0xebb1);
+  static const IconData? library_sharp = IoniconsData(0xebb1);
 
   /// link
-  static const IconData link = IoniconsData(0xebb2);
+  static const IconData? link = IoniconsData(0xebb2);
 
   /// link-outline
-  static const IconData link_outline = IoniconsData(0xebb3);
+  static const IconData? link_outline = IoniconsData(0xebb3);
 
   /// link-sharp
-  static const IconData link_sharp = IoniconsData(0xebb4);
+  static const IconData? link_sharp = IoniconsData(0xebb4);
 
   /// list
-  static const IconData list = IoniconsData(0xebb5);
+  static const IconData? list = IoniconsData(0xebb5);
 
   /// list-circle
-  static const IconData list_circle = IoniconsData(0xebb6);
+  static const IconData? list_circle = IoniconsData(0xebb6);
 
   /// list-circle-outline
-  static const IconData list_circle_outline = IoniconsData(0xebb7);
+  static const IconData? list_circle_outline = IoniconsData(0xebb7);
 
   /// list-circle-sharp
-  static const IconData list_circle_sharp = IoniconsData(0xebb8);
+  static const IconData? list_circle_sharp = IoniconsData(0xebb8);
 
   /// list-outline
-  static const IconData list_outline = IoniconsData(0xebb9);
+  static const IconData? list_outline = IoniconsData(0xebb9);
 
   /// list-sharp
-  static const IconData list_sharp = IoniconsData(0xebba);
+  static const IconData? list_sharp = IoniconsData(0xebba);
 
   /// locate
-  static const IconData locate = IoniconsData(0xebbb);
+  static const IconData? locate = IoniconsData(0xebbb);
 
   /// locate-outline
-  static const IconData locate_outline = IoniconsData(0xebbc);
+  static const IconData? locate_outline = IoniconsData(0xebbc);
 
   /// locate-sharp
-  static const IconData locate_sharp = IoniconsData(0xebbd);
+  static const IconData? locate_sharp = IoniconsData(0xebbd);
 
   /// location
-  static const IconData location = IoniconsData(0xebbe);
+  static const IconData? location = IoniconsData(0xebbe);
 
   /// location-outline
-  static const IconData location_outline = IoniconsData(0xebbf);
+  static const IconData? location_outline = IoniconsData(0xebbf);
 
   /// location-sharp
-  static const IconData location_sharp = IoniconsData(0xebc0);
+  static const IconData? location_sharp = IoniconsData(0xebc0);
 
   /// lock-closed
-  static const IconData lock_closed = IoniconsData(0xebc1);
+  static const IconData? lock_closed = IoniconsData(0xebc1);
 
   /// lock-closed-outline
-  static const IconData lock_closed_outline = IoniconsData(0xebc2);
+  static const IconData? lock_closed_outline = IoniconsData(0xebc2);
 
   /// lock-closed-sharp
-  static const IconData lock_closed_sharp = IoniconsData(0xebc3);
+  static const IconData? lock_closed_sharp = IoniconsData(0xebc3);
 
   /// lock-open
-  static const IconData lock_open = IoniconsData(0xebc4);
+  static const IconData? lock_open = IoniconsData(0xebc4);
 
   /// lock-open-outline
-  static const IconData lock_open_outline = IoniconsData(0xebc5);
+  static const IconData? lock_open_outline = IoniconsData(0xebc5);
 
   /// lock-open-sharp
-  static const IconData lock_open_sharp = IoniconsData(0xebc6);
+  static const IconData? lock_open_sharp = IoniconsData(0xebc6);
 
   /// log-in
-  static const IconData log_in = IoniconsData(0xebc7);
+  static const IconData? log_in = IoniconsData(0xebc7);
 
   /// log-in-outline
-  static const IconData log_in_outline = IoniconsData(0xebc8);
+  static const IconData? log_in_outline = IoniconsData(0xebc8);
 
   /// log-in-sharp
-  static const IconData log_in_sharp = IoniconsData(0xebc9);
+  static const IconData? log_in_sharp = IoniconsData(0xebc9);
 
   /// logo-alipay
-  static const IconData logo_alipay = IoniconsData(0xebca);
+  static const IconData? logo_alipay = IoniconsData(0xebca);
 
   /// logo-amazon
-  static const IconData logo_amazon = IoniconsData(0xebcb);
+  static const IconData? logo_amazon = IoniconsData(0xebcb);
 
   /// logo-amplify
-  static const IconData logo_amplify = IoniconsData(0xebcc);
+  static const IconData? logo_amplify = IoniconsData(0xebcc);
 
   /// logo-android
-  static const IconData logo_android = IoniconsData(0xebcd);
+  static const IconData? logo_android = IoniconsData(0xebcd);
 
   /// logo-angular
-  static const IconData logo_angular = IoniconsData(0xebce);
+  static const IconData? logo_angular = IoniconsData(0xebce);
 
   /// logo-apple
-  static const IconData logo_apple = IoniconsData(0xebcf);
+  static const IconData? logo_apple = IoniconsData(0xebcf);
 
   /// logo-apple-appstore
-  static const IconData logo_apple_appstore = IoniconsData(0xebd0);
+  static const IconData? logo_apple_appstore = IoniconsData(0xebd0);
 
   /// logo-apple-ar
-  static const IconData logo_apple_ar = IoniconsData(0xebd1);
+  static const IconData? logo_apple_ar = IoniconsData(0xebd1);
 
   /// logo-behance
-  static const IconData logo_behance = IoniconsData(0xebd2);
+  static const IconData? logo_behance = IoniconsData(0xebd2);
 
   /// logo-bitbucket
-  static const IconData logo_bitbucket = IoniconsData(0xebd3);
+  static const IconData? logo_bitbucket = IoniconsData(0xebd3);
 
   /// logo-bitcoin
-  static const IconData logo_bitcoin = IoniconsData(0xebd4);
+  static const IconData? logo_bitcoin = IoniconsData(0xebd4);
 
   /// logo-buffer
-  static const IconData logo_buffer = IoniconsData(0xebd5);
+  static const IconData? logo_buffer = IoniconsData(0xebd5);
 
   /// logo-capacitor
-  static const IconData logo_capacitor = IoniconsData(0xebd6);
+  static const IconData? logo_capacitor = IoniconsData(0xebd6);
 
   /// logo-chrome
-  static const IconData logo_chrome = IoniconsData(0xebd7);
+  static const IconData? logo_chrome = IoniconsData(0xebd7);
 
   /// logo-closed-captioning
-  static const IconData logo_closed_captioning = IoniconsData(0xebd8);
+  static const IconData? logo_closed_captioning = IoniconsData(0xebd8);
 
   /// logo-codepen
-  static const IconData logo_codepen = IoniconsData(0xebd9);
+  static const IconData? logo_codepen = IoniconsData(0xebd9);
 
   /// logo-css3
-  static const IconData logo_css3 = IoniconsData(0xebda);
+  static const IconData? logo_css3 = IoniconsData(0xebda);
 
   /// logo-designernews
-  static const IconData logo_designernews = IoniconsData(0xebdb);
+  static const IconData? logo_designernews = IoniconsData(0xebdb);
 
   /// logo-deviantart
-  static const IconData logo_deviantart = IoniconsData(0xebdc);
+  static const IconData? logo_deviantart = IoniconsData(0xebdc);
 
   /// logo-discord
-  static const IconData logo_discord = IoniconsData(0xebdd);
+  static const IconData? logo_discord = IoniconsData(0xebdd);
 
   /// logo-docker
-  static const IconData logo_docker = IoniconsData(0xebde);
+  static const IconData? logo_docker = IoniconsData(0xebde);
 
   /// logo-dribbble
-  static const IconData logo_dribbble = IoniconsData(0xebdf);
+  static const IconData? logo_dribbble = IoniconsData(0xebdf);
 
   /// logo-dropbox
-  static const IconData logo_dropbox = IoniconsData(0xebe0);
+  static const IconData? logo_dropbox = IoniconsData(0xebe0);
 
   /// logo-edge
-  static const IconData logo_edge = IoniconsData(0xebe1);
+  static const IconData? logo_edge = IoniconsData(0xebe1);
 
   /// logo-electron
-  static const IconData logo_electron = IoniconsData(0xebe2);
+  static const IconData? logo_electron = IoniconsData(0xebe2);
 
   /// logo-euro
-  static const IconData logo_euro = IoniconsData(0xebe3);
+  static const IconData? logo_euro = IoniconsData(0xebe3);
 
   /// logo-facebook
-  static const IconData logo_facebook = IoniconsData(0xebe4);
+  static const IconData? logo_facebook = IoniconsData(0xebe4);
 
   /// logo-figma
-  static const IconData logo_figma = IoniconsData(0xebe5);
+  static const IconData? logo_figma = IoniconsData(0xebe5);
 
   /// logo-firebase
-  static const IconData logo_firebase = IoniconsData(0xebe6);
+  static const IconData? logo_firebase = IoniconsData(0xebe6);
 
   /// logo-firefox
-  static const IconData logo_firefox = IoniconsData(0xebe7);
+  static const IconData? logo_firefox = IoniconsData(0xebe7);
 
   /// logo-flickr
-  static const IconData logo_flickr = IoniconsData(0xebe8);
+  static const IconData? logo_flickr = IoniconsData(0xebe8);
 
   /// logo-foursquare
-  static const IconData logo_foursquare = IoniconsData(0xebe9);
+  static const IconData? logo_foursquare = IoniconsData(0xebe9);
 
   /// logo-github
-  static const IconData logo_github = IoniconsData(0xebea);
+  static const IconData? logo_github = IoniconsData(0xebea);
 
   /// logo-gitlab
-  static const IconData logo_gitlab = IoniconsData(0xebeb);
+  static const IconData? logo_gitlab = IoniconsData(0xebeb);
 
   /// logo-google
-  static const IconData logo_google = IoniconsData(0xebec);
+  static const IconData? logo_google = IoniconsData(0xebec);
 
   /// logo-google-playstore
-  static const IconData logo_google_playstore = IoniconsData(0xebed);
+  static const IconData? logo_google_playstore = IoniconsData(0xebed);
 
   /// logo-hackernews
-  static const IconData logo_hackernews = IoniconsData(0xebee);
+  static const IconData? logo_hackernews = IoniconsData(0xebee);
 
   /// logo-html5
-  static const IconData logo_html5 = IoniconsData(0xebef);
+  static const IconData? logo_html5 = IoniconsData(0xebef);
 
   /// logo-instagram
-  static const IconData logo_instagram = IoniconsData(0xebf0);
+  static const IconData? logo_instagram = IoniconsData(0xebf0);
 
   /// logo-ionic
-  static const IconData logo_ionic = IoniconsData(0xebf1);
+  static const IconData? logo_ionic = IoniconsData(0xebf1);
 
   /// logo-ionitron
-  static const IconData logo_ionitron = IoniconsData(0xebf2);
+  static const IconData? logo_ionitron = IoniconsData(0xebf2);
 
   /// logo-javascript
-  static const IconData logo_javascript = IoniconsData(0xebf3);
+  static const IconData? logo_javascript = IoniconsData(0xebf3);
 
   /// logo-laravel
-  static const IconData logo_laravel = IoniconsData(0xebf4);
+  static const IconData? logo_laravel = IoniconsData(0xebf4);
 
   /// logo-linkedin
-  static const IconData logo_linkedin = IoniconsData(0xebf5);
+  static const IconData? logo_linkedin = IoniconsData(0xebf5);
 
   /// logo-markdown
-  static const IconData logo_markdown = IoniconsData(0xebf6);
+  static const IconData? logo_markdown = IoniconsData(0xebf6);
 
   /// logo-mastodon
-  static const IconData logo_mastodon = IoniconsData(0xebf7);
+  static const IconData? logo_mastodon = IoniconsData(0xebf7);
 
   /// logo-medium
-  static const IconData logo_medium = IoniconsData(0xebf8);
+  static const IconData? logo_medium = IoniconsData(0xebf8);
 
   /// logo-microsoft
-  static const IconData logo_microsoft = IoniconsData(0xebf9);
+  static const IconData? logo_microsoft = IoniconsData(0xebf9);
 
   /// logo-nodejs
-  static const IconData logo_nodejs = IoniconsData(0xebfa);
+  static const IconData? logo_nodejs = IoniconsData(0xebfa);
 
   /// logo-no-smoking
-  static const IconData logo_no_smoking = IoniconsData(0xebfb);
+  static const IconData? logo_no_smoking = IoniconsData(0xebfb);
 
   /// logo-npm
-  static const IconData logo_npm = IoniconsData(0xebfc);
+  static const IconData? logo_npm = IoniconsData(0xebfc);
 
   /// logo-octocat
-  static const IconData logo_octocat = IoniconsData(0xebfd);
+  static const IconData? logo_octocat = IoniconsData(0xebfd);
 
   /// logo-paypal
-  static const IconData logo_paypal = IoniconsData(0xebfe);
+  static const IconData? logo_paypal = IoniconsData(0xebfe);
 
   /// logo-pinterest
-  static const IconData logo_pinterest = IoniconsData(0xebff);
+  static const IconData? logo_pinterest = IoniconsData(0xebff);
 
   /// logo-playstation
-  static const IconData logo_playstation = IoniconsData(0xec00);
+  static const IconData? logo_playstation = IoniconsData(0xec00);
 
   /// logo-pwa
-  static const IconData logo_pwa = IoniconsData(0xec01);
+  static const IconData? logo_pwa = IoniconsData(0xec01);
 
   /// logo-python
-  static const IconData logo_python = IoniconsData(0xec02);
+  static const IconData? logo_python = IoniconsData(0xec02);
 
   /// logo-react
-  static const IconData logo_react = IoniconsData(0xec03);
+  static const IconData? logo_react = IoniconsData(0xec03);
 
   /// logo-reddit
-  static const IconData logo_reddit = IoniconsData(0xec04);
+  static const IconData? logo_reddit = IoniconsData(0xec04);
 
   /// logo-rss
-  static const IconData logo_rss = IoniconsData(0xec05);
+  static const IconData? logo_rss = IoniconsData(0xec05);
 
   /// logo-sass
-  static const IconData logo_sass = IoniconsData(0xec06);
+  static const IconData? logo_sass = IoniconsData(0xec06);
 
   /// logo-skype
-  static const IconData logo_skype = IoniconsData(0xec07);
+  static const IconData? logo_skype = IoniconsData(0xec07);
 
   /// logo-slack
-  static const IconData logo_slack = IoniconsData(0xec08);
+  static const IconData? logo_slack = IoniconsData(0xec08);
 
   /// logo-snapchat
-  static const IconData logo_snapchat = IoniconsData(0xec09);
+  static const IconData? logo_snapchat = IoniconsData(0xec09);
 
   /// logo-soundcloud
-  static const IconData logo_soundcloud = IoniconsData(0xec0a);
+  static const IconData? logo_soundcloud = IoniconsData(0xec0a);
 
   /// logo-stackoverflow
-  static const IconData logo_stackoverflow = IoniconsData(0xec0b);
+  static const IconData? logo_stackoverflow = IoniconsData(0xec0b);
 
   /// logo-steam
-  static const IconData logo_steam = IoniconsData(0xec0c);
+  static const IconData? logo_steam = IoniconsData(0xec0c);
 
   /// logo-stencil
-  static const IconData logo_stencil = IoniconsData(0xec0d);
+  static const IconData? logo_stencil = IoniconsData(0xec0d);
 
   /// logo-tableau
-  static const IconData logo_tableau = IoniconsData(0xec0e);
+  static const IconData? logo_tableau = IoniconsData(0xec0e);
 
   /// logo-tiktok
-  static const IconData logo_tiktok = IoniconsData(0xec0f);
+  static const IconData? logo_tiktok = IoniconsData(0xec0f);
 
   /// logo-tumblr
-  static const IconData logo_tumblr = IoniconsData(0xec10);
+  static const IconData? logo_tumblr = IoniconsData(0xec10);
 
   /// logo-tux
-  static const IconData logo_tux = IoniconsData(0xec11);
+  static const IconData? logo_tux = IoniconsData(0xec11);
 
   /// logo-twitch
-  static const IconData logo_twitch = IoniconsData(0xec12);
+  static const IconData? logo_twitch = IoniconsData(0xec12);
 
   /// logo-twitter
-  static const IconData logo_twitter = IoniconsData(0xec13);
+  static const IconData? logo_twitter = IoniconsData(0xec13);
 
   /// logo-usd
-  static const IconData logo_usd = IoniconsData(0xec14);
+  static const IconData? logo_usd = IoniconsData(0xec14);
 
   /// log-out
-  static const IconData log_out = IoniconsData(0xec15);
+  static const IconData? log_out = IoniconsData(0xec15);
 
   /// log-out-outline
-  static const IconData log_out_outline = IoniconsData(0xec16);
+  static const IconData? log_out_outline = IoniconsData(0xec16);
 
   /// log-out-sharp
-  static const IconData log_out_sharp = IoniconsData(0xec17);
+  static const IconData? log_out_sharp = IoniconsData(0xec17);
 
   /// logo-venmo
-  static const IconData logo_venmo = IoniconsData(0xec18);
+  static const IconData? logo_venmo = IoniconsData(0xec18);
 
   /// logo-vercel
-  static const IconData logo_vercel = IoniconsData(0xec19);
+  static const IconData? logo_vercel = IoniconsData(0xec19);
 
   /// logo-vimeo
-  static const IconData logo_vimeo = IoniconsData(0xec1a);
+  static const IconData? logo_vimeo = IoniconsData(0xec1a);
 
   /// logo-vk
-  static const IconData logo_vk = IoniconsData(0xec1b);
+  static const IconData? logo_vk = IoniconsData(0xec1b);
 
   /// logo-vue
-  static const IconData logo_vue = IoniconsData(0xec1c);
+  static const IconData? logo_vue = IoniconsData(0xec1c);
 
   /// logo-web-component
-  static const IconData logo_web_component = IoniconsData(0xec1d);
+  static const IconData? logo_web_component = IoniconsData(0xec1d);
 
   /// logo-wechat
-  static const IconData logo_wechat = IoniconsData(0xec1e);
+  static const IconData? logo_wechat = IoniconsData(0xec1e);
 
   /// logo-whatsapp
-  static const IconData logo_whatsapp = IoniconsData(0xec1f);
+  static const IconData? logo_whatsapp = IoniconsData(0xec1f);
 
   /// logo-windows
-  static const IconData logo_windows = IoniconsData(0xec20);
+  static const IconData? logo_windows = IoniconsData(0xec20);
 
   /// logo-wordpress
-  static const IconData logo_wordpress = IoniconsData(0xec21);
+  static const IconData? logo_wordpress = IoniconsData(0xec21);
 
   /// logo-xbox
-  static const IconData logo_xbox = IoniconsData(0xec22);
+  static const IconData? logo_xbox = IoniconsData(0xec22);
 
   /// logo-xing
-  static const IconData logo_xing = IoniconsData(0xec23);
+  static const IconData? logo_xing = IoniconsData(0xec23);
 
   /// logo-yahoo
-  static const IconData logo_yahoo = IoniconsData(0xec24);
+  static const IconData? logo_yahoo = IoniconsData(0xec24);
 
   /// logo-yen
-  static const IconData logo_yen = IoniconsData(0xec25);
+  static const IconData? logo_yen = IoniconsData(0xec25);
 
   /// logo-youtube
-  static const IconData logo_youtube = IoniconsData(0xec26);
+  static const IconData? logo_youtube = IoniconsData(0xec26);
 
   /// magnet
-  static const IconData magnet = IoniconsData(0xec27);
+  static const IconData? magnet = IoniconsData(0xec27);
 
   /// magnet-outline
-  static const IconData magnet_outline = IoniconsData(0xec28);
+  static const IconData? magnet_outline = IoniconsData(0xec28);
 
   /// magnet-sharp
-  static const IconData magnet_sharp = IoniconsData(0xec29);
+  static const IconData? magnet_sharp = IoniconsData(0xec29);
 
   /// mail
-  static const IconData mail = IoniconsData(0xec2a);
+  static const IconData? mail = IoniconsData(0xec2a);
 
   /// mail-open
-  static const IconData mail_open = IoniconsData(0xec2b);
+  static const IconData? mail_open = IoniconsData(0xec2b);
 
   /// mail-open-outline
-  static const IconData mail_open_outline = IoniconsData(0xec2c);
+  static const IconData? mail_open_outline = IoniconsData(0xec2c);
 
   /// mail-open-sharp
-  static const IconData mail_open_sharp = IoniconsData(0xec2d);
+  static const IconData? mail_open_sharp = IoniconsData(0xec2d);
 
   /// mail-outline
-  static const IconData mail_outline = IoniconsData(0xec2e);
+  static const IconData? mail_outline = IoniconsData(0xec2e);
 
   /// mail-sharp
-  static const IconData mail_sharp = IoniconsData(0xec2f);
+  static const IconData? mail_sharp = IoniconsData(0xec2f);
 
   /// mail-unread
-  static const IconData mail_unread = IoniconsData(0xec30);
+  static const IconData? mail_unread = IoniconsData(0xec30);
 
   /// mail-unread-outline
-  static const IconData mail_unread_outline = IoniconsData(0xec31);
+  static const IconData? mail_unread_outline = IoniconsData(0xec31);
 
   /// mail-unread-sharp
-  static const IconData mail_unread_sharp = IoniconsData(0xec32);
+  static const IconData? mail_unread_sharp = IoniconsData(0xec32);
 
   /// male
-  static const IconData male = IoniconsData(0xec33);
+  static const IconData? male = IoniconsData(0xec33);
 
   /// male-female
-  static const IconData male_female = IoniconsData(0xec34);
+  static const IconData? male_female = IoniconsData(0xec34);
 
   /// male-female-outline
-  static const IconData male_female_outline = IoniconsData(0xec35);
+  static const IconData? male_female_outline = IoniconsData(0xec35);
 
   /// male-female-sharp
-  static const IconData male_female_sharp = IoniconsData(0xec36);
+  static const IconData? male_female_sharp = IoniconsData(0xec36);
 
   /// male-outline
-  static const IconData male_outline = IoniconsData(0xec37);
+  static const IconData? male_outline = IoniconsData(0xec37);
 
   /// male-sharp
-  static const IconData male_sharp = IoniconsData(0xec38);
+  static const IconData? male_sharp = IoniconsData(0xec38);
 
   /// man
-  static const IconData man = IoniconsData(0xec39);
+  static const IconData? man = IoniconsData(0xec39);
 
   /// man-outline
-  static const IconData man_outline = IoniconsData(0xec3a);
+  static const IconData? man_outline = IoniconsData(0xec3a);
 
   /// man-sharp
-  static const IconData man_sharp = IoniconsData(0xec3b);
+  static const IconData? man_sharp = IoniconsData(0xec3b);
 
   /// map
-  static const IconData map = IoniconsData(0xec3c);
+  static const IconData? map = IoniconsData(0xec3c);
 
   /// map-outline
-  static const IconData map_outline = IoniconsData(0xec3d);
+  static const IconData? map_outline = IoniconsData(0xec3d);
 
   /// map-sharp
-  static const IconData map_sharp = IoniconsData(0xec3e);
+  static const IconData? map_sharp = IoniconsData(0xec3e);
 
   /// medal
-  static const IconData medal = IoniconsData(0xec3f);
+  static const IconData? medal = IoniconsData(0xec3f);
 
   /// medal-outline
-  static const IconData medal_outline = IoniconsData(0xec40);
+  static const IconData? medal_outline = IoniconsData(0xec40);
 
   /// medal-sharp
-  static const IconData medal_sharp = IoniconsData(0xec41);
+  static const IconData? medal_sharp = IoniconsData(0xec41);
 
   /// medical
-  static const IconData medical = IoniconsData(0xec42);
+  static const IconData? medical = IoniconsData(0xec42);
 
   /// medical-outline
-  static const IconData medical_outline = IoniconsData(0xec43);
+  static const IconData? medical_outline = IoniconsData(0xec43);
 
   /// medical-sharp
-  static const IconData medical_sharp = IoniconsData(0xec44);
+  static const IconData? medical_sharp = IoniconsData(0xec44);
 
   /// medkit
-  static const IconData medkit = IoniconsData(0xec45);
+  static const IconData? medkit = IoniconsData(0xec45);
 
   /// medkit-outline
-  static const IconData medkit_outline = IoniconsData(0xec46);
+  static const IconData? medkit_outline = IoniconsData(0xec46);
 
   /// medkit-sharp
-  static const IconData medkit_sharp = IoniconsData(0xec47);
+  static const IconData? medkit_sharp = IoniconsData(0xec47);
 
   /// megaphone
-  static const IconData megaphone = IoniconsData(0xec48);
+  static const IconData? megaphone = IoniconsData(0xec48);
 
   /// megaphone-outline
-  static const IconData megaphone_outline = IoniconsData(0xec49);
+  static const IconData? megaphone_outline = IoniconsData(0xec49);
 
   /// megaphone-sharp
-  static const IconData megaphone_sharp = IoniconsData(0xec4a);
+  static const IconData? megaphone_sharp = IoniconsData(0xec4a);
 
   /// menu
-  static const IconData menu = IoniconsData(0xec4b);
+  static const IconData? menu = IoniconsData(0xec4b);
 
   /// menu-outline
-  static const IconData menu_outline = IoniconsData(0xec4c);
+  static const IconData? menu_outline = IoniconsData(0xec4c);
 
   /// menu-sharp
-  static const IconData menu_sharp = IoniconsData(0xec4d);
+  static const IconData? menu_sharp = IoniconsData(0xec4d);
 
   /// mic
-  static const IconData mic = IoniconsData(0xec4e);
+  static const IconData? mic = IoniconsData(0xec4e);
 
   /// mic-circle
-  static const IconData mic_circle = IoniconsData(0xec4f);
+  static const IconData? mic_circle = IoniconsData(0xec4f);
 
   /// mic-circle-outline
-  static const IconData mic_circle_outline = IoniconsData(0xec50);
+  static const IconData? mic_circle_outline = IoniconsData(0xec50);
 
   /// mic-circle-sharp
-  static const IconData mic_circle_sharp = IoniconsData(0xec51);
+  static const IconData? mic_circle_sharp = IoniconsData(0xec51);
 
   /// mic-off
-  static const IconData mic_off = IoniconsData(0xec52);
+  static const IconData? mic_off = IoniconsData(0xec52);
 
   /// mic-off-circle
-  static const IconData mic_off_circle = IoniconsData(0xec53);
+  static const IconData? mic_off_circle = IoniconsData(0xec53);
 
   /// mic-off-circle-outline
-  static const IconData mic_off_circle_outline = IoniconsData(0xec54);
+  static const IconData? mic_off_circle_outline = IoniconsData(0xec54);
 
   /// mic-off-circle-sharp
-  static const IconData mic_off_circle_sharp = IoniconsData(0xec55);
+  static const IconData? mic_off_circle_sharp = IoniconsData(0xec55);
 
   /// mic-off-outline
-  static const IconData mic_off_outline = IoniconsData(0xec56);
+  static const IconData? mic_off_outline = IoniconsData(0xec56);
 
   /// mic-off-sharp
-  static const IconData mic_off_sharp = IoniconsData(0xec57);
+  static const IconData? mic_off_sharp = IoniconsData(0xec57);
 
   /// mic-outline
-  static const IconData mic_outline = IoniconsData(0xec58);
+  static const IconData? mic_outline = IoniconsData(0xec58);
 
   /// mic-sharp
-  static const IconData mic_sharp = IoniconsData(0xec59);
+  static const IconData? mic_sharp = IoniconsData(0xec59);
 
   /// moon
-  static const IconData moon = IoniconsData(0xec5a);
+  static const IconData? moon = IoniconsData(0xec5a);
 
   /// moon-outline
-  static const IconData moon_outline = IoniconsData(0xec5b);
+  static const IconData? moon_outline = IoniconsData(0xec5b);
 
   /// moon-sharp
-  static const IconData moon_sharp = IoniconsData(0xec5c);
+  static const IconData? moon_sharp = IoniconsData(0xec5c);
 
   /// move
-  static const IconData move = IoniconsData(0xec5d);
+  static const IconData? move = IoniconsData(0xec5d);
 
   /// move-outline
-  static const IconData move_outline = IoniconsData(0xec5e);
+  static const IconData? move_outline = IoniconsData(0xec5e);
 
   /// move-sharp
-  static const IconData move_sharp = IoniconsData(0xec5f);
+  static const IconData? move_sharp = IoniconsData(0xec5f);
 
   /// musical-note
-  static const IconData musical_note = IoniconsData(0xec60);
+  static const IconData? musical_note = IoniconsData(0xec60);
 
   /// musical-note-outline
-  static const IconData musical_note_outline = IoniconsData(0xec61);
+  static const IconData? musical_note_outline = IoniconsData(0xec61);
 
   /// musical-notes
-  static const IconData musical_notes = IoniconsData(0xec62);
+  static const IconData? musical_notes = IoniconsData(0xec62);
 
   /// musical-note-sharp
-  static const IconData musical_note_sharp = IoniconsData(0xec63);
+  static const IconData? musical_note_sharp = IoniconsData(0xec63);
 
   /// musical-notes-outline
-  static const IconData musical_notes_outline = IoniconsData(0xec64);
+  static const IconData? musical_notes_outline = IoniconsData(0xec64);
 
   /// musical-notes-sharp
-  static const IconData musical_notes_sharp = IoniconsData(0xec65);
+  static const IconData? musical_notes_sharp = IoniconsData(0xec65);
 
   /// navigate
-  static const IconData navigate = IoniconsData(0xec66);
+  static const IconData? navigate = IoniconsData(0xec66);
 
   /// navigate-circle
-  static const IconData navigate_circle = IoniconsData(0xec67);
+  static const IconData? navigate_circle = IoniconsData(0xec67);
 
   /// navigate-circle-outline
-  static const IconData navigate_circle_outline = IoniconsData(0xec68);
+  static const IconData? navigate_circle_outline = IoniconsData(0xec68);
 
   /// navigate-circle-sharp
-  static const IconData navigate_circle_sharp = IoniconsData(0xec69);
+  static const IconData? navigate_circle_sharp = IoniconsData(0xec69);
 
   /// navigate-outline
-  static const IconData navigate_outline = IoniconsData(0xec6a);
+  static const IconData? navigate_outline = IoniconsData(0xec6a);
 
   /// navigate-sharp
-  static const IconData navigate_sharp = IoniconsData(0xec6b);
+  static const IconData? navigate_sharp = IoniconsData(0xec6b);
 
   /// newspaper
-  static const IconData newspaper = IoniconsData(0xec6c);
+  static const IconData? newspaper = IoniconsData(0xec6c);
 
   /// newspaper-outline
-  static const IconData newspaper_outline = IoniconsData(0xec6d);
+  static const IconData? newspaper_outline = IoniconsData(0xec6d);
 
   /// newspaper-sharp
-  static const IconData newspaper_sharp = IoniconsData(0xec6e);
+  static const IconData? newspaper_sharp = IoniconsData(0xec6e);
 
   /// notifications
-  static const IconData notifications = IoniconsData(0xec6f);
+  static const IconData? notifications = IoniconsData(0xec6f);
 
   /// notifications-circle
-  static const IconData notifications_circle = IoniconsData(0xec70);
+  static const IconData? notifications_circle = IoniconsData(0xec70);
 
   /// notifications-circle-outline
-  static const IconData notifications_circle_outline = IoniconsData(0xec71);
+  static const IconData? notifications_circle_outline = IoniconsData(0xec71);
 
   /// notifications-circle-sharp
-  static const IconData notifications_circle_sharp = IoniconsData(0xec72);
+  static const IconData? notifications_circle_sharp = IoniconsData(0xec72);
 
   /// notifications-off
-  static const IconData notifications_off = IoniconsData(0xec73);
+  static const IconData? notifications_off = IoniconsData(0xec73);
 
   /// notifications-off-circle
-  static const IconData notifications_off_circle = IoniconsData(0xec74);
+  static const IconData? notifications_off_circle = IoniconsData(0xec74);
 
   /// notifications-off-circle-outline
-  static const IconData notifications_off_circle_outline = IoniconsData(0xec75);
+  static const IconData? notifications_off_circle_outline = IoniconsData(0xec75);
 
   /// notifications-off-circle-sharp
-  static const IconData notifications_off_circle_sharp = IoniconsData(0xec76);
+  static const IconData? notifications_off_circle_sharp = IoniconsData(0xec76);
 
   /// notifications-off-outline
-  static const IconData notifications_off_outline = IoniconsData(0xec77);
+  static const IconData? notifications_off_outline = IoniconsData(0xec77);
 
   /// notifications-off-sharp
-  static const IconData notifications_off_sharp = IoniconsData(0xec78);
+  static const IconData? notifications_off_sharp = IoniconsData(0xec78);
 
   /// notifications-outline
-  static const IconData notifications_outline = IoniconsData(0xec79);
+  static const IconData? notifications_outline = IoniconsData(0xec79);
 
   /// notifications-sharp
-  static const IconData notifications_sharp = IoniconsData(0xec7a);
+  static const IconData? notifications_sharp = IoniconsData(0xec7a);
 
   /// nuclear
-  static const IconData nuclear = IoniconsData(0xec7b);
+  static const IconData? nuclear = IoniconsData(0xec7b);
 
   /// nuclear-outline
-  static const IconData nuclear_outline = IoniconsData(0xec7c);
+  static const IconData? nuclear_outline = IoniconsData(0xec7c);
 
   /// nuclear-sharp
-  static const IconData nuclear_sharp = IoniconsData(0xec7d);
+  static const IconData? nuclear_sharp = IoniconsData(0xec7d);
 
   /// nutrition
-  static const IconData nutrition = IoniconsData(0xec7e);
+  static const IconData? nutrition = IoniconsData(0xec7e);
 
   /// nutrition-outline
-  static const IconData nutrition_outline = IoniconsData(0xec7f);
+  static const IconData? nutrition_outline = IoniconsData(0xec7f);
 
   /// nutrition-sharp
-  static const IconData nutrition_sharp = IoniconsData(0xec80);
+  static const IconData? nutrition_sharp = IoniconsData(0xec80);
 
   /// open
-  static const IconData open = IoniconsData(0xec81);
+  static const IconData? open = IoniconsData(0xec81);
 
   /// open-outline
-  static const IconData open_outline = IoniconsData(0xec82);
+  static const IconData? open_outline = IoniconsData(0xec82);
 
   /// open-sharp
-  static const IconData open_sharp = IoniconsData(0xec83);
+  static const IconData? open_sharp = IoniconsData(0xec83);
 
   /// options
-  static const IconData options = IoniconsData(0xec84);
+  static const IconData? options = IoniconsData(0xec84);
 
   /// options-outline
-  static const IconData options_outline = IoniconsData(0xec85);
+  static const IconData? options_outline = IoniconsData(0xec85);
 
   /// options-sharp
-  static const IconData options_sharp = IoniconsData(0xec86);
+  static const IconData? options_sharp = IoniconsData(0xec86);
 
   /// paper-plane
-  static const IconData paper_plane = IoniconsData(0xec87);
+  static const IconData? paper_plane = IoniconsData(0xec87);
 
   /// paper-plane-outline
-  static const IconData paper_plane_outline = IoniconsData(0xec88);
+  static const IconData? paper_plane_outline = IoniconsData(0xec88);
 
   /// paper-plane-sharp
-  static const IconData paper_plane_sharp = IoniconsData(0xec89);
+  static const IconData? paper_plane_sharp = IoniconsData(0xec89);
 
   /// partly-sunny
-  static const IconData partly_sunny = IoniconsData(0xec8a);
+  static const IconData? partly_sunny = IoniconsData(0xec8a);
 
   /// partly-sunny-outline
-  static const IconData partly_sunny_outline = IoniconsData(0xec8b);
+  static const IconData? partly_sunny_outline = IoniconsData(0xec8b);
 
   /// partly-sunny-sharp
-  static const IconData partly_sunny_sharp = IoniconsData(0xec8c);
+  static const IconData? partly_sunny_sharp = IoniconsData(0xec8c);
 
   /// pause
-  static const IconData pause = IoniconsData(0xec8d);
+  static const IconData? pause = IoniconsData(0xec8d);
 
   /// pause-circle
-  static const IconData pause_circle = IoniconsData(0xec8e);
+  static const IconData? pause_circle = IoniconsData(0xec8e);
 
   /// pause-circle-outline
-  static const IconData pause_circle_outline = IoniconsData(0xec8f);
+  static const IconData? pause_circle_outline = IoniconsData(0xec8f);
 
   /// pause-circle-sharp
-  static const IconData pause_circle_sharp = IoniconsData(0xec90);
+  static const IconData? pause_circle_sharp = IoniconsData(0xec90);
 
   /// pause-outline
-  static const IconData pause_outline = IoniconsData(0xec91);
+  static const IconData? pause_outline = IoniconsData(0xec91);
 
   /// pause-sharp
-  static const IconData pause_sharp = IoniconsData(0xec92);
+  static const IconData? pause_sharp = IoniconsData(0xec92);
 
   /// paw
-  static const IconData paw = IoniconsData(0xec93);
+  static const IconData? paw = IoniconsData(0xec93);
 
   /// paw-outline
-  static const IconData paw_outline = IoniconsData(0xec94);
+  static const IconData? paw_outline = IoniconsData(0xec94);
 
   /// paw-sharp
-  static const IconData paw_sharp = IoniconsData(0xec95);
+  static const IconData? paw_sharp = IoniconsData(0xec95);
 
   /// pencil
-  static const IconData pencil = IoniconsData(0xec96);
+  static const IconData? pencil = IoniconsData(0xec96);
 
   /// pencil-outline
-  static const IconData pencil_outline = IoniconsData(0xec97);
+  static const IconData? pencil_outline = IoniconsData(0xec97);
 
   /// pencil-sharp
-  static const IconData pencil_sharp = IoniconsData(0xec98);
+  static const IconData? pencil_sharp = IoniconsData(0xec98);
 
   /// people
-  static const IconData people = IoniconsData(0xec99);
+  static const IconData? people = IoniconsData(0xec99);
 
   /// people-circle
-  static const IconData people_circle = IoniconsData(0xec9a);
+  static const IconData? people_circle = IoniconsData(0xec9a);
 
   /// people-circle-outline
-  static const IconData people_circle_outline = IoniconsData(0xec9b);
+  static const IconData? people_circle_outline = IoniconsData(0xec9b);
 
   /// people-circle-sharp
-  static const IconData people_circle_sharp = IoniconsData(0xec9c);
+  static const IconData? people_circle_sharp = IoniconsData(0xec9c);
 
   /// people-outline
-  static const IconData people_outline = IoniconsData(0xec9d);
+  static const IconData? people_outline = IoniconsData(0xec9d);
 
   /// people-sharp
-  static const IconData people_sharp = IoniconsData(0xec9e);
+  static const IconData? people_sharp = IoniconsData(0xec9e);
 
   /// person
-  static const IconData person = IoniconsData(0xec9f);
+  static const IconData? person = IoniconsData(0xec9f);
 
   /// person-add
-  static const IconData person_add = IoniconsData(0xeca0);
+  static const IconData? person_add = IoniconsData(0xeca0);
 
   /// person-add-outline
-  static const IconData person_add_outline = IoniconsData(0xeca1);
+  static const IconData? person_add_outline = IoniconsData(0xeca1);
 
   /// person-add-sharp
-  static const IconData person_add_sharp = IoniconsData(0xeca2);
+  static const IconData? person_add_sharp = IoniconsData(0xeca2);
 
   /// person-circle
-  static const IconData person_circle = IoniconsData(0xeca3);
+  static const IconData? person_circle = IoniconsData(0xeca3);
 
   /// person-circle-outline
-  static const IconData person_circle_outline = IoniconsData(0xeca4);
+  static const IconData? person_circle_outline = IoniconsData(0xeca4);
 
   /// person-circle-sharp
-  static const IconData person_circle_sharp = IoniconsData(0xeca5);
+  static const IconData? person_circle_sharp = IoniconsData(0xeca5);
 
   /// person-outline
-  static const IconData person_outline = IoniconsData(0xeca6);
+  static const IconData? person_outline = IoniconsData(0xeca6);
 
   /// person-remove
-  static const IconData person_remove = IoniconsData(0xeca7);
+  static const IconData? person_remove = IoniconsData(0xeca7);
 
   /// person-remove-outline
-  static const IconData person_remove_outline = IoniconsData(0xeca8);
+  static const IconData? person_remove_outline = IoniconsData(0xeca8);
 
   /// person-remove-sharp
-  static const IconData person_remove_sharp = IoniconsData(0xeca9);
+  static const IconData? person_remove_sharp = IoniconsData(0xeca9);
 
   /// person-sharp
-  static const IconData person_sharp = IoniconsData(0xecaa);
+  static const IconData? person_sharp = IoniconsData(0xecaa);
 
   /// phone-landscape
-  static const IconData phone_landscape = IoniconsData(0xecab);
+  static const IconData? phone_landscape = IoniconsData(0xecab);
 
   /// phone-landscape-outline
-  static const IconData phone_landscape_outline = IoniconsData(0xecac);
+  static const IconData? phone_landscape_outline = IoniconsData(0xecac);
 
   /// phone-landscape-sharp
-  static const IconData phone_landscape_sharp = IoniconsData(0xecad);
+  static const IconData? phone_landscape_sharp = IoniconsData(0xecad);
 
   /// phone-portrait
-  static const IconData phone_portrait = IoniconsData(0xecae);
+  static const IconData? phone_portrait = IoniconsData(0xecae);
 
   /// phone-portrait-outline
-  static const IconData phone_portrait_outline = IoniconsData(0xecaf);
+  static const IconData? phone_portrait_outline = IoniconsData(0xecaf);
 
   /// phone-portrait-sharp
-  static const IconData phone_portrait_sharp = IoniconsData(0xecb0);
+  static const IconData? phone_portrait_sharp = IoniconsData(0xecb0);
 
   /// pie-chart
-  static const IconData pie_chart = IoniconsData(0xecb1);
+  static const IconData? pie_chart = IoniconsData(0xecb1);
 
   /// pie-chart-outline
-  static const IconData pie_chart_outline = IoniconsData(0xecb2);
+  static const IconData? pie_chart_outline = IoniconsData(0xecb2);
 
   /// pie-chart-sharp
-  static const IconData pie_chart_sharp = IoniconsData(0xecb3);
+  static const IconData? pie_chart_sharp = IoniconsData(0xecb3);
 
   /// pin
-  static const IconData pin = IoniconsData(0xecb4);
+  static const IconData? pin = IoniconsData(0xecb4);
 
   /// pin-outline
-  static const IconData pin_outline = IoniconsData(0xecb5);
+  static const IconData? pin_outline = IoniconsData(0xecb5);
 
   /// pin-sharp
-  static const IconData pin_sharp = IoniconsData(0xecb6);
+  static const IconData? pin_sharp = IoniconsData(0xecb6);
 
   /// pint
-  static const IconData pint = IoniconsData(0xecb7);
+  static const IconData? pint = IoniconsData(0xecb7);
 
   /// pint-outline
-  static const IconData pint_outline = IoniconsData(0xecb8);
+  static const IconData? pint_outline = IoniconsData(0xecb8);
 
   /// pint-sharp
-  static const IconData pint_sharp = IoniconsData(0xecb9);
+  static const IconData? pint_sharp = IoniconsData(0xecb9);
 
   /// pizza
-  static const IconData pizza = IoniconsData(0xecba);
+  static const IconData? pizza = IoniconsData(0xecba);
 
   /// pizza-outline
-  static const IconData pizza_outline = IoniconsData(0xecbb);
+  static const IconData? pizza_outline = IoniconsData(0xecbb);
 
   /// pizza-sharp
-  static const IconData pizza_sharp = IoniconsData(0xecbc);
+  static const IconData? pizza_sharp = IoniconsData(0xecbc);
 
   /// planet
-  static const IconData planet = IoniconsData(0xecbd);
+  static const IconData? planet = IoniconsData(0xecbd);
 
   /// planet-outline
-  static const IconData planet_outline = IoniconsData(0xecbe);
+  static const IconData? planet_outline = IoniconsData(0xecbe);
 
   /// planet-sharp
-  static const IconData planet_sharp = IoniconsData(0xecbf);
+  static const IconData? planet_sharp = IoniconsData(0xecbf);
 
   /// play
-  static const IconData play = IoniconsData(0xecc0);
+  static const IconData? play = IoniconsData(0xecc0);
 
   /// play-back
-  static const IconData play_back = IoniconsData(0xecc1);
+  static const IconData? play_back = IoniconsData(0xecc1);
 
   /// play-back-circle
-  static const IconData play_back_circle = IoniconsData(0xecc2);
+  static const IconData? play_back_circle = IoniconsData(0xecc2);
 
   /// play-back-circle-outline
-  static const IconData play_back_circle_outline = IoniconsData(0xecc3);
+  static const IconData? play_back_circle_outline = IoniconsData(0xecc3);
 
   /// play-back-circle-sharp
-  static const IconData play_back_circle_sharp = IoniconsData(0xecc4);
+  static const IconData? play_back_circle_sharp = IoniconsData(0xecc4);
 
   /// play-back-outline
-  static const IconData play_back_outline = IoniconsData(0xecc5);
+  static const IconData? play_back_outline = IoniconsData(0xecc5);
 
   /// play-back-sharp
-  static const IconData play_back_sharp = IoniconsData(0xecc6);
+  static const IconData? play_back_sharp = IoniconsData(0xecc6);
 
   /// play-circle
-  static const IconData play_circle = IoniconsData(0xecc7);
+  static const IconData? play_circle = IoniconsData(0xecc7);
 
   /// play-circle-outline
-  static const IconData play_circle_outline = IoniconsData(0xecc8);
+  static const IconData? play_circle_outline = IoniconsData(0xecc8);
 
   /// play-circle-sharp
-  static const IconData play_circle_sharp = IoniconsData(0xecc9);
+  static const IconData? play_circle_sharp = IoniconsData(0xecc9);
 
   /// play-forward
-  static const IconData play_forward = IoniconsData(0xecca);
+  static const IconData? play_forward = IoniconsData(0xecca);
 
   /// play-forward-circle
-  static const IconData play_forward_circle = IoniconsData(0xeccb);
+  static const IconData? play_forward_circle = IoniconsData(0xeccb);
 
   /// play-forward-circle-outline
-  static const IconData play_forward_circle_outline = IoniconsData(0xeccc);
+  static const IconData? play_forward_circle_outline = IoniconsData(0xeccc);
 
   /// play-forward-circle-sharp
-  static const IconData play_forward_circle_sharp = IoniconsData(0xeccd);
+  static const IconData? play_forward_circle_sharp = IoniconsData(0xeccd);
 
   /// play-forward-outline
-  static const IconData play_forward_outline = IoniconsData(0xecce);
+  static const IconData? play_forward_outline = IoniconsData(0xecce);
 
   /// play-forward-sharp
-  static const IconData play_forward_sharp = IoniconsData(0xeccf);
+  static const IconData? play_forward_sharp = IoniconsData(0xeccf);
 
   /// play-outline
-  static const IconData play_outline = IoniconsData(0xecd0);
+  static const IconData? play_outline = IoniconsData(0xecd0);
 
   /// play-sharp
-  static const IconData play_sharp = IoniconsData(0xecd1);
+  static const IconData? play_sharp = IoniconsData(0xecd1);
 
   /// play-skip-back
-  static const IconData play_skip_back = IoniconsData(0xecd2);
+  static const IconData? play_skip_back = IoniconsData(0xecd2);
 
   /// play-skip-back-circle
-  static const IconData play_skip_back_circle = IoniconsData(0xecd3);
+  static const IconData? play_skip_back_circle = IoniconsData(0xecd3);
 
   /// play-skip-back-circle-outline
-  static const IconData play_skip_back_circle_outline = IoniconsData(0xecd4);
+  static const IconData? play_skip_back_circle_outline = IoniconsData(0xecd4);
 
   /// play-skip-back-circle-sharp
-  static const IconData play_skip_back_circle_sharp = IoniconsData(0xecd5);
+  static const IconData? play_skip_back_circle_sharp = IoniconsData(0xecd5);
 
   /// play-skip-back-outline
-  static const IconData play_skip_back_outline = IoniconsData(0xecd6);
+  static const IconData? play_skip_back_outline = IoniconsData(0xecd6);
 
   /// play-skip-back-sharp
-  static const IconData play_skip_back_sharp = IoniconsData(0xecd7);
+  static const IconData? play_skip_back_sharp = IoniconsData(0xecd7);
 
   /// play-skip-forward
-  static const IconData play_skip_forward = IoniconsData(0xecd8);
+  static const IconData? play_skip_forward = IoniconsData(0xecd8);
 
   /// play-skip-forward-circle
-  static const IconData play_skip_forward_circle = IoniconsData(0xecd9);
+  static const IconData? play_skip_forward_circle = IoniconsData(0xecd9);
 
   /// play-skip-forward-circle-outline
-  static const IconData play_skip_forward_circle_outline = IoniconsData(0xecda);
+  static const IconData? play_skip_forward_circle_outline = IoniconsData(0xecda);
 
   /// play-skip-forward-circle-sharp
-  static const IconData play_skip_forward_circle_sharp = IoniconsData(0xecdb);
+  static const IconData? play_skip_forward_circle_sharp = IoniconsData(0xecdb);
 
   /// play-skip-forward-outline
-  static const IconData play_skip_forward_outline = IoniconsData(0xecdc);
+  static const IconData? play_skip_forward_outline = IoniconsData(0xecdc);
 
   /// play-skip-forward-sharp
-  static const IconData play_skip_forward_sharp = IoniconsData(0xecdd);
+  static const IconData? play_skip_forward_sharp = IoniconsData(0xecdd);
 
   /// podium
-  static const IconData podium = IoniconsData(0xecde);
+  static const IconData? podium = IoniconsData(0xecde);
 
   /// podium-outline
-  static const IconData podium_outline = IoniconsData(0xecdf);
+  static const IconData? podium_outline = IoniconsData(0xecdf);
 
   /// podium-sharp
-  static const IconData podium_sharp = IoniconsData(0xece0);
+  static const IconData? podium_sharp = IoniconsData(0xece0);
 
   /// power
-  static const IconData power = IoniconsData(0xece1);
+  static const IconData? power = IoniconsData(0xece1);
 
   /// power-outline
-  static const IconData power_outline = IoniconsData(0xece2);
+  static const IconData? power_outline = IoniconsData(0xece2);
 
   /// power-sharp
-  static const IconData power_sharp = IoniconsData(0xece3);
+  static const IconData? power_sharp = IoniconsData(0xece3);
 
   /// pricetag
-  static const IconData pricetag = IoniconsData(0xece4);
+  static const IconData? pricetag = IoniconsData(0xece4);
 
   /// pricetag-outline
-  static const IconData pricetag_outline = IoniconsData(0xece5);
+  static const IconData? pricetag_outline = IoniconsData(0xece5);
 
   /// pricetags
-  static const IconData pricetags = IoniconsData(0xece6);
+  static const IconData? pricetags = IoniconsData(0xece6);
 
   /// pricetag-sharp
-  static const IconData pricetag_sharp = IoniconsData(0xece7);
+  static const IconData? pricetag_sharp = IoniconsData(0xece7);
 
   /// pricetags-outline
-  static const IconData pricetags_outline = IoniconsData(0xece8);
+  static const IconData? pricetags_outline = IoniconsData(0xece8);
 
   /// pricetags-sharp
-  static const IconData pricetags_sharp = IoniconsData(0xece9);
+  static const IconData? pricetags_sharp = IoniconsData(0xece9);
 
   /// print
-  static const IconData print = IoniconsData(0xecea);
+  static const IconData? print = IoniconsData(0xecea);
 
   /// print-outline
-  static const IconData print_outline = IoniconsData(0xeceb);
+  static const IconData? print_outline = IoniconsData(0xeceb);
 
   /// print-sharp
-  static const IconData print_sharp = IoniconsData(0xecec);
+  static const IconData? print_sharp = IoniconsData(0xecec);
 
   /// prism
-  static const IconData prism = IoniconsData(0xeced);
+  static const IconData? prism = IoniconsData(0xeced);
 
   /// prism-outline
-  static const IconData prism_outline = IoniconsData(0xecee);
+  static const IconData? prism_outline = IoniconsData(0xecee);
 
   /// prism-sharp
-  static const IconData prism_sharp = IoniconsData(0xecef);
+  static const IconData? prism_sharp = IoniconsData(0xecef);
 
   /// pulse
-  static const IconData pulse = IoniconsData(0xecf0);
+  static const IconData? pulse = IoniconsData(0xecf0);
 
   /// pulse-outline
-  static const IconData pulse_outline = IoniconsData(0xecf1);
+  static const IconData? pulse_outline = IoniconsData(0xecf1);
 
   /// pulse-sharp
-  static const IconData pulse_sharp = IoniconsData(0xecf2);
+  static const IconData? pulse_sharp = IoniconsData(0xecf2);
 
   /// push
-  static const IconData push = IoniconsData(0xecf3);
+  static const IconData? push = IoniconsData(0xecf3);
 
   /// push-outline
-  static const IconData push_outline = IoniconsData(0xecf4);
+  static const IconData? push_outline = IoniconsData(0xecf4);
 
   /// push-sharp
-  static const IconData push_sharp = IoniconsData(0xecf5);
+  static const IconData? push_sharp = IoniconsData(0xecf5);
 
   /// qr-code
-  static const IconData qr_code = IoniconsData(0xecf6);
+  static const IconData? qr_code = IoniconsData(0xecf6);
 
   /// qr-code-outline
-  static const IconData qr_code_outline = IoniconsData(0xecf7);
+  static const IconData? qr_code_outline = IoniconsData(0xecf7);
 
   /// qr-code-sharp
-  static const IconData qr_code_sharp = IoniconsData(0xecf8);
+  static const IconData? qr_code_sharp = IoniconsData(0xecf8);
 
   /// radio
-  static const IconData radio = IoniconsData(0xecf9);
+  static const IconData? radio = IoniconsData(0xecf9);
 
   /// radio-button-off
-  static const IconData radio_button_off = IoniconsData(0xecfa);
+  static const IconData? radio_button_off = IoniconsData(0xecfa);
 
   /// radio-button-off-outline
-  static const IconData radio_button_off_outline = IoniconsData(0xecfb);
+  static const IconData? radio_button_off_outline = IoniconsData(0xecfb);
 
   /// radio-button-off-sharp
-  static const IconData radio_button_off_sharp = IoniconsData(0xecfc);
+  static const IconData? radio_button_off_sharp = IoniconsData(0xecfc);
 
   /// radio-button-on
-  static const IconData radio_button_on = IoniconsData(0xecfd);
+  static const IconData? radio_button_on = IoniconsData(0xecfd);
 
   /// radio-button-on-outline
-  static const IconData radio_button_on_outline = IoniconsData(0xecfe);
+  static const IconData? radio_button_on_outline = IoniconsData(0xecfe);
 
   /// radio-button-on-sharp
-  static const IconData radio_button_on_sharp = IoniconsData(0xecff);
+  static const IconData? radio_button_on_sharp = IoniconsData(0xecff);
 
   /// radio-outline
-  static const IconData radio_outline = IoniconsData(0xed00);
+  static const IconData? radio_outline = IoniconsData(0xed00);
 
   /// radio-sharp
-  static const IconData radio_sharp = IoniconsData(0xed01);
+  static const IconData? radio_sharp = IoniconsData(0xed01);
 
   /// rainy
-  static const IconData rainy = IoniconsData(0xed02);
+  static const IconData? rainy = IoniconsData(0xed02);
 
   /// rainy-outline
-  static const IconData rainy_outline = IoniconsData(0xed03);
+  static const IconData? rainy_outline = IoniconsData(0xed03);
 
   /// rainy-sharp
-  static const IconData rainy_sharp = IoniconsData(0xed04);
+  static const IconData? rainy_sharp = IoniconsData(0xed04);
 
   /// reader
-  static const IconData reader = IoniconsData(0xed05);
+  static const IconData? reader = IoniconsData(0xed05);
 
   /// reader-outline
-  static const IconData reader_outline = IoniconsData(0xed06);
+  static const IconData? reader_outline = IoniconsData(0xed06);
 
   /// reader-sharp
-  static const IconData reader_sharp = IoniconsData(0xed07);
+  static const IconData? reader_sharp = IoniconsData(0xed07);
 
   /// receipt
-  static const IconData receipt = IoniconsData(0xed08);
+  static const IconData? receipt = IoniconsData(0xed08);
 
   /// receipt-outline
-  static const IconData receipt_outline = IoniconsData(0xed09);
+  static const IconData? receipt_outline = IoniconsData(0xed09);
 
   /// receipt-sharp
-  static const IconData receipt_sharp = IoniconsData(0xed0a);
+  static const IconData? receipt_sharp = IoniconsData(0xed0a);
 
   /// recording
-  static const IconData recording = IoniconsData(0xed0b);
+  static const IconData? recording = IoniconsData(0xed0b);
 
   /// recording-outline
-  static const IconData recording_outline = IoniconsData(0xed0c);
+  static const IconData? recording_outline = IoniconsData(0xed0c);
 
   /// recording-sharp
-  static const IconData recording_sharp = IoniconsData(0xed0d);
+  static const IconData? recording_sharp = IoniconsData(0xed0d);
 
   /// refresh
-  static const IconData refresh = IoniconsData(0xed0e);
+  static const IconData? refresh = IoniconsData(0xed0e);
 
   /// refresh-circle
-  static const IconData refresh_circle = IoniconsData(0xed0f);
+  static const IconData? refresh_circle = IoniconsData(0xed0f);
 
   /// refresh-circle-outline
-  static const IconData refresh_circle_outline = IoniconsData(0xed10);
+  static const IconData? refresh_circle_outline = IoniconsData(0xed10);
 
   /// refresh-circle-sharp
-  static const IconData refresh_circle_sharp = IoniconsData(0xed11);
+  static const IconData? refresh_circle_sharp = IoniconsData(0xed11);
 
   /// refresh-outline
-  static const IconData refresh_outline = IoniconsData(0xed12);
+  static const IconData? refresh_outline = IoniconsData(0xed12);
 
   /// refresh-sharp
-  static const IconData refresh_sharp = IoniconsData(0xed13);
+  static const IconData? refresh_sharp = IoniconsData(0xed13);
 
   /// reload
-  static const IconData reload = IoniconsData(0xed14);
+  static const IconData? reload = IoniconsData(0xed14);
 
   /// reload-circle
-  static const IconData reload_circle = IoniconsData(0xed15);
+  static const IconData? reload_circle = IoniconsData(0xed15);
 
   /// reload-circle-outline
-  static const IconData reload_circle_outline = IoniconsData(0xed16);
+  static const IconData? reload_circle_outline = IoniconsData(0xed16);
 
   /// reload-circle-sharp
-  static const IconData reload_circle_sharp = IoniconsData(0xed17);
+  static const IconData? reload_circle_sharp = IoniconsData(0xed17);
 
   /// reload-outline
-  static const IconData reload_outline = IoniconsData(0xed18);
+  static const IconData? reload_outline = IoniconsData(0xed18);
 
   /// reload-sharp
-  static const IconData reload_sharp = IoniconsData(0xed19);
+  static const IconData? reload_sharp = IoniconsData(0xed19);
 
   /// remove
-  static const IconData remove = IoniconsData(0xed1a);
+  static const IconData? remove = IoniconsData(0xed1a);
 
   /// remove-circle
-  static const IconData remove_circle = IoniconsData(0xed1b);
+  static const IconData? remove_circle = IoniconsData(0xed1b);
 
   /// remove-circle-outline
-  static const IconData remove_circle_outline = IoniconsData(0xed1c);
+  static const IconData? remove_circle_outline = IoniconsData(0xed1c);
 
   /// remove-circle-sharp
-  static const IconData remove_circle_sharp = IoniconsData(0xed1d);
+  static const IconData? remove_circle_sharp = IoniconsData(0xed1d);
 
   /// remove-outline
-  static const IconData remove_outline = IoniconsData(0xed1e);
+  static const IconData? remove_outline = IoniconsData(0xed1e);
 
   /// remove-sharp
-  static const IconData remove_sharp = IoniconsData(0xed1f);
+  static const IconData? remove_sharp = IoniconsData(0xed1f);
 
   /// reorder-four
-  static const IconData reorder_four = IoniconsData(0xed20);
+  static const IconData? reorder_four = IoniconsData(0xed20);
 
   /// reorder-four-outline
-  static const IconData reorder_four_outline = IoniconsData(0xed21);
+  static const IconData? reorder_four_outline = IoniconsData(0xed21);
 
   /// reorder-four-sharp
-  static const IconData reorder_four_sharp = IoniconsData(0xed22);
+  static const IconData? reorder_four_sharp = IoniconsData(0xed22);
 
   /// reorder-three
-  static const IconData reorder_three = IoniconsData(0xed23);
+  static const IconData? reorder_three = IoniconsData(0xed23);
 
   /// reorder-three-outline
-  static const IconData reorder_three_outline = IoniconsData(0xed24);
+  static const IconData? reorder_three_outline = IoniconsData(0xed24);
 
   /// reorder-three-sharp
-  static const IconData reorder_three_sharp = IoniconsData(0xed25);
+  static const IconData? reorder_three_sharp = IoniconsData(0xed25);
 
   /// reorder-two
-  static const IconData reorder_two = IoniconsData(0xed26);
+  static const IconData? reorder_two = IoniconsData(0xed26);
 
   /// reorder-two-outline
-  static const IconData reorder_two_outline = IoniconsData(0xed27);
+  static const IconData? reorder_two_outline = IoniconsData(0xed27);
 
   /// reorder-two-sharp
-  static const IconData reorder_two_sharp = IoniconsData(0xed28);
+  static const IconData? reorder_two_sharp = IoniconsData(0xed28);
 
   /// repeat
-  static const IconData repeat = IoniconsData(0xed29);
+  static const IconData? repeat = IoniconsData(0xed29);
 
   /// repeat-outline
-  static const IconData repeat_outline = IoniconsData(0xed2a);
+  static const IconData? repeat_outline = IoniconsData(0xed2a);
 
   /// repeat-sharp
-  static const IconData repeat_sharp = IoniconsData(0xed2b);
+  static const IconData? repeat_sharp = IoniconsData(0xed2b);
 
   /// resize
-  static const IconData resize = IoniconsData(0xed2c);
+  static const IconData? resize = IoniconsData(0xed2c);
 
   /// resize-outline
-  static const IconData resize_outline = IoniconsData(0xed2d);
+  static const IconData? resize_outline = IoniconsData(0xed2d);
 
   /// resize-sharp
-  static const IconData resize_sharp = IoniconsData(0xed2e);
+  static const IconData? resize_sharp = IoniconsData(0xed2e);
 
   /// restaurant
-  static const IconData restaurant = IoniconsData(0xed2f);
+  static const IconData? restaurant = IoniconsData(0xed2f);
 
   /// restaurant-outline
-  static const IconData restaurant_outline = IoniconsData(0xed30);
+  static const IconData? restaurant_outline = IoniconsData(0xed30);
 
   /// restaurant-sharp
-  static const IconData restaurant_sharp = IoniconsData(0xed31);
+  static const IconData? restaurant_sharp = IoniconsData(0xed31);
 
   /// return-down-back
-  static const IconData return_down_back = IoniconsData(0xed32);
+  static const IconData? return_down_back = IoniconsData(0xed32);
 
   /// return-down-back-outline
-  static const IconData return_down_back_outline = IoniconsData(0xed33);
+  static const IconData? return_down_back_outline = IoniconsData(0xed33);
 
   /// return-down-back-sharp
-  static const IconData return_down_back_sharp = IoniconsData(0xed34);
+  static const IconData? return_down_back_sharp = IoniconsData(0xed34);
 
   /// return-down-forward
-  static const IconData return_down_forward = IoniconsData(0xed35);
+  static const IconData? return_down_forward = IoniconsData(0xed35);
 
   /// return-down-forward-outline
-  static const IconData return_down_forward_outline = IoniconsData(0xed36);
+  static const IconData? return_down_forward_outline = IoniconsData(0xed36);
 
   /// return-down-forward-sharp
-  static const IconData return_down_forward_sharp = IoniconsData(0xed37);
+  static const IconData? return_down_forward_sharp = IoniconsData(0xed37);
 
   /// return-up-back
-  static const IconData return_up_back = IoniconsData(0xed38);
+  static const IconData? return_up_back = IoniconsData(0xed38);
 
   /// return-up-back-outline
-  static const IconData return_up_back_outline = IoniconsData(0xed39);
+  static const IconData? return_up_back_outline = IoniconsData(0xed39);
 
   /// return-up-back-sharp
-  static const IconData return_up_back_sharp = IoniconsData(0xed3a);
+  static const IconData? return_up_back_sharp = IoniconsData(0xed3a);
 
   /// return-up-forward
-  static const IconData return_up_forward = IoniconsData(0xed3b);
+  static const IconData? return_up_forward = IoniconsData(0xed3b);
 
   /// return-up-forward-outline
-  static const IconData return_up_forward_outline = IoniconsData(0xed3c);
+  static const IconData? return_up_forward_outline = IoniconsData(0xed3c);
 
   /// return-up-forward-sharp
-  static const IconData return_up_forward_sharp = IoniconsData(0xed3d);
+  static const IconData? return_up_forward_sharp = IoniconsData(0xed3d);
 
   /// ribbon
-  static const IconData ribbon = IoniconsData(0xed3e);
+  static const IconData? ribbon = IoniconsData(0xed3e);
 
   /// ribbon-outline
-  static const IconData ribbon_outline = IoniconsData(0xed3f);
+  static const IconData? ribbon_outline = IoniconsData(0xed3f);
 
   /// ribbon-sharp
-  static const IconData ribbon_sharp = IoniconsData(0xed40);
+  static const IconData? ribbon_sharp = IoniconsData(0xed40);
 
   /// rocket
-  static const IconData rocket = IoniconsData(0xed41);
+  static const IconData? rocket = IoniconsData(0xed41);
 
   /// rocket-outline
-  static const IconData rocket_outline = IoniconsData(0xed42);
+  static const IconData? rocket_outline = IoniconsData(0xed42);
 
   /// rocket-sharp
-  static const IconData rocket_sharp = IoniconsData(0xed43);
+  static const IconData? rocket_sharp = IoniconsData(0xed43);
 
   /// rose
-  static const IconData rose = IoniconsData(0xed44);
+  static const IconData? rose = IoniconsData(0xed44);
 
   /// rose-outline
-  static const IconData rose_outline = IoniconsData(0xed45);
+  static const IconData? rose_outline = IoniconsData(0xed45);
 
   /// rose-sharp
-  static const IconData rose_sharp = IoniconsData(0xed46);
+  static const IconData? rose_sharp = IoniconsData(0xed46);
 
   /// sad
-  static const IconData sad = IoniconsData(0xed47);
+  static const IconData? sad = IoniconsData(0xed47);
 
   /// sad-outline
-  static const IconData sad_outline = IoniconsData(0xed48);
+  static const IconData? sad_outline = IoniconsData(0xed48);
 
   /// sad-sharp
-  static const IconData sad_sharp = IoniconsData(0xed49);
+  static const IconData? sad_sharp = IoniconsData(0xed49);
 
   /// save
-  static const IconData save = IoniconsData(0xed4a);
+  static const IconData? save = IoniconsData(0xed4a);
 
   /// save-outline
-  static const IconData save_outline = IoniconsData(0xed4b);
+  static const IconData? save_outline = IoniconsData(0xed4b);
 
   /// save-sharp
-  static const IconData save_sharp = IoniconsData(0xed4c);
+  static const IconData? save_sharp = IoniconsData(0xed4c);
 
   /// scale
-  static const IconData scale = IoniconsData(0xed4d);
+  static const IconData? scale = IoniconsData(0xed4d);
 
   /// scale-outline
-  static const IconData scale_outline = IoniconsData(0xed4e);
+  static const IconData? scale_outline = IoniconsData(0xed4e);
 
   /// scale-sharp
-  static const IconData scale_sharp = IoniconsData(0xed4f);
+  static const IconData? scale_sharp = IoniconsData(0xed4f);
 
   /// scan
-  static const IconData scan = IoniconsData(0xed50);
+  static const IconData? scan = IoniconsData(0xed50);
 
   /// scan-circle
-  static const IconData scan_circle = IoniconsData(0xed51);
+  static const IconData? scan_circle = IoniconsData(0xed51);
 
   /// scan-circle-outline
-  static const IconData scan_circle_outline = IoniconsData(0xed52);
+  static const IconData? scan_circle_outline = IoniconsData(0xed52);
 
   /// scan-circle-sharp
-  static const IconData scan_circle_sharp = IoniconsData(0xed53);
+  static const IconData? scan_circle_sharp = IoniconsData(0xed53);
 
   /// scan-outline
-  static const IconData scan_outline = IoniconsData(0xed54);
+  static const IconData? scan_outline = IoniconsData(0xed54);
 
   /// scan-sharp
-  static const IconData scan_sharp = IoniconsData(0xed55);
+  static const IconData? scan_sharp = IoniconsData(0xed55);
 
   /// school
-  static const IconData school = IoniconsData(0xed56);
+  static const IconData? school = IoniconsData(0xed56);
 
   /// school-outline
-  static const IconData school_outline = IoniconsData(0xed57);
+  static const IconData? school_outline = IoniconsData(0xed57);
 
   /// school-sharp
-  static const IconData school_sharp = IoniconsData(0xed58);
+  static const IconData? school_sharp = IoniconsData(0xed58);
 
   /// search
-  static const IconData search = IoniconsData(0xed59);
+  static const IconData? search = IoniconsData(0xed59);
 
   /// search-circle
-  static const IconData search_circle = IoniconsData(0xed5a);
+  static const IconData? search_circle = IoniconsData(0xed5a);
 
   /// search-circle-outline
-  static const IconData search_circle_outline = IoniconsData(0xed5b);
+  static const IconData? search_circle_outline = IoniconsData(0xed5b);
 
   /// search-circle-sharp
-  static const IconData search_circle_sharp = IoniconsData(0xed5c);
+  static const IconData? search_circle_sharp = IoniconsData(0xed5c);
 
   /// search-outline
-  static const IconData search_outline = IoniconsData(0xed5d);
+  static const IconData? search_outline = IoniconsData(0xed5d);
 
   /// search-sharp
-  static const IconData search_sharp = IoniconsData(0xed5e);
+  static const IconData? search_sharp = IoniconsData(0xed5e);
 
   /// send
-  static const IconData send = IoniconsData(0xed5f);
+  static const IconData? send = IoniconsData(0xed5f);
 
   /// send-outline
-  static const IconData send_outline = IoniconsData(0xed60);
+  static const IconData? send_outline = IoniconsData(0xed60);
 
   /// send-sharp
-  static const IconData send_sharp = IoniconsData(0xed61);
+  static const IconData? send_sharp = IoniconsData(0xed61);
 
   /// server
-  static const IconData server = IoniconsData(0xed62);
+  static const IconData? server = IoniconsData(0xed62);
 
   /// server-outline
-  static const IconData server_outline = IoniconsData(0xed63);
+  static const IconData? server_outline = IoniconsData(0xed63);
 
   /// server-sharp
-  static const IconData server_sharp = IoniconsData(0xed64);
+  static const IconData? server_sharp = IoniconsData(0xed64);
 
   /// settings
-  static const IconData settings = IoniconsData(0xed65);
+  static const IconData? settings = IoniconsData(0xed65);
 
   /// settings-outline
-  static const IconData settings_outline = IoniconsData(0xed66);
+  static const IconData? settings_outline = IoniconsData(0xed66);
 
   /// settings-sharp
-  static const IconData settings_sharp = IoniconsData(0xed67);
+  static const IconData? settings_sharp = IoniconsData(0xed67);
 
   /// shapes
-  static const IconData shapes = IoniconsData(0xed68);
+  static const IconData? shapes = IoniconsData(0xed68);
 
   /// shapes-outline
-  static const IconData shapes_outline = IoniconsData(0xed69);
+  static const IconData? shapes_outline = IoniconsData(0xed69);
 
   /// shapes-sharp
-  static const IconData shapes_sharp = IoniconsData(0xed6a);
+  static const IconData? shapes_sharp = IoniconsData(0xed6a);
 
   /// share
-  static const IconData share = IoniconsData(0xed6b);
+  static const IconData? share = IoniconsData(0xed6b);
 
   /// share-outline
-  static const IconData share_outline = IoniconsData(0xed6c);
+  static const IconData? share_outline = IoniconsData(0xed6c);
 
   /// share-sharp
-  static const IconData share_sharp = IoniconsData(0xed6d);
+  static const IconData? share_sharp = IoniconsData(0xed6d);
 
   /// share-social
-  static const IconData share_social = IoniconsData(0xed6e);
+  static const IconData? share_social = IoniconsData(0xed6e);
 
   /// share-social-outline
-  static const IconData share_social_outline = IoniconsData(0xed6f);
+  static const IconData? share_social_outline = IoniconsData(0xed6f);
 
   /// share-social-sharp
-  static const IconData share_social_sharp = IoniconsData(0xed70);
+  static const IconData? share_social_sharp = IoniconsData(0xed70);
 
   /// shield
-  static const IconData shield = IoniconsData(0xed71);
+  static const IconData? shield = IoniconsData(0xed71);
 
   /// shield-checkmark
-  static const IconData shield_checkmark = IoniconsData(0xed72);
+  static const IconData? shield_checkmark = IoniconsData(0xed72);
 
   /// shield-checkmark-outline
-  static const IconData shield_checkmark_outline = IoniconsData(0xed73);
+  static const IconData? shield_checkmark_outline = IoniconsData(0xed73);
 
   /// shield-checkmark-sharp
-  static const IconData shield_checkmark_sharp = IoniconsData(0xed74);
+  static const IconData? shield_checkmark_sharp = IoniconsData(0xed74);
 
   /// shield-half
-  static const IconData shield_half = IoniconsData(0xed75);
+  static const IconData? shield_half = IoniconsData(0xed75);
 
   /// shield-half-outline
-  static const IconData shield_half_outline = IoniconsData(0xed76);
+  static const IconData? shield_half_outline = IoniconsData(0xed76);
 
   /// shield-half-sharp
-  static const IconData shield_half_sharp = IoniconsData(0xed77);
+  static const IconData? shield_half_sharp = IoniconsData(0xed77);
 
   /// shield-outline
-  static const IconData shield_outline = IoniconsData(0xed78);
+  static const IconData? shield_outline = IoniconsData(0xed78);
 
   /// shield-sharp
-  static const IconData shield_sharp = IoniconsData(0xed79);
+  static const IconData? shield_sharp = IoniconsData(0xed79);
 
   /// shirt
-  static const IconData shirt = IoniconsData(0xed7a);
+  static const IconData? shirt = IoniconsData(0xed7a);
 
   /// shirt-outline
-  static const IconData shirt_outline = IoniconsData(0xed7b);
+  static const IconData? shirt_outline = IoniconsData(0xed7b);
 
   /// shirt-sharp
-  static const IconData shirt_sharp = IoniconsData(0xed7c);
+  static const IconData? shirt_sharp = IoniconsData(0xed7c);
 
   /// shuffle
-  static const IconData shuffle = IoniconsData(0xed7d);
+  static const IconData? shuffle = IoniconsData(0xed7d);
 
   /// shuffle-outline
-  static const IconData shuffle_outline = IoniconsData(0xed7e);
+  static const IconData? shuffle_outline = IoniconsData(0xed7e);
 
   /// shuffle-sharp
-  static const IconData shuffle_sharp = IoniconsData(0xed7f);
+  static const IconData? shuffle_sharp = IoniconsData(0xed7f);
 
   /// skull
-  static const IconData skull = IoniconsData(0xed80);
+  static const IconData? skull = IoniconsData(0xed80);
 
   /// skull-outline
-  static const IconData skull_outline = IoniconsData(0xed81);
+  static const IconData? skull_outline = IoniconsData(0xed81);
 
   /// skull-sharp
-  static const IconData skull_sharp = IoniconsData(0xed82);
+  static const IconData? skull_sharp = IoniconsData(0xed82);
 
   /// snow
-  static const IconData snow = IoniconsData(0xed83);
+  static const IconData? snow = IoniconsData(0xed83);
 
   /// snow-outline
-  static const IconData snow_outline = IoniconsData(0xed84);
+  static const IconData? snow_outline = IoniconsData(0xed84);
 
   /// snow-sharp
-  static const IconData snow_sharp = IoniconsData(0xed85);
+  static const IconData? snow_sharp = IoniconsData(0xed85);
 
   /// sparkles
-  static const IconData sparkles = IoniconsData(0xed86);
+  static const IconData? sparkles = IoniconsData(0xed86);
 
   /// sparkles-outline
-  static const IconData sparkles_outline = IoniconsData(0xed87);
+  static const IconData? sparkles_outline = IoniconsData(0xed87);
 
   /// sparkles-sharp
-  static const IconData sparkles_sharp = IoniconsData(0xed88);
+  static const IconData? sparkles_sharp = IoniconsData(0xed88);
 
   /// speedometer
-  static const IconData speedometer = IoniconsData(0xed89);
+  static const IconData? speedometer = IoniconsData(0xed89);
 
   /// speedometer-outline
-  static const IconData speedometer_outline = IoniconsData(0xed8a);
+  static const IconData? speedometer_outline = IoniconsData(0xed8a);
 
   /// speedometer-sharp
-  static const IconData speedometer_sharp = IoniconsData(0xed8b);
+  static const IconData? speedometer_sharp = IoniconsData(0xed8b);
 
   /// square
-  static const IconData square = IoniconsData(0xed8c);
+  static const IconData? square = IoniconsData(0xed8c);
 
   /// square-outline
-  static const IconData square_outline = IoniconsData(0xed8d);
+  static const IconData? square_outline = IoniconsData(0xed8d);
 
   /// square-sharp
-  static const IconData square_sharp = IoniconsData(0xed8e);
+  static const IconData? square_sharp = IoniconsData(0xed8e);
 
   /// star
-  static const IconData star = IoniconsData(0xed8f);
+  static const IconData? star = IoniconsData(0xed8f);
 
   /// star-half
-  static const IconData star_half = IoniconsData(0xed90);
+  static const IconData? star_half = IoniconsData(0xed90);
 
   /// star-half-outline
-  static const IconData star_half_outline = IoniconsData(0xed91);
+  static const IconData? star_half_outline = IoniconsData(0xed91);
 
   /// star-half-sharp
-  static const IconData star_half_sharp = IoniconsData(0xed92);
+  static const IconData? star_half_sharp = IoniconsData(0xed92);
 
   /// star-outline
-  static const IconData star_outline = IoniconsData(0xed93);
+  static const IconData? star_outline = IoniconsData(0xed93);
 
   /// star-sharp
-  static const IconData star_sharp = IoniconsData(0xed94);
+  static const IconData? star_sharp = IoniconsData(0xed94);
 
   /// stats-chart
-  static const IconData stats_chart = IoniconsData(0xed95);
+  static const IconData? stats_chart = IoniconsData(0xed95);
 
   /// stats-chart-outline
-  static const IconData stats_chart_outline = IoniconsData(0xed96);
+  static const IconData? stats_chart_outline = IoniconsData(0xed96);
 
   /// stats-chart-sharp
-  static const IconData stats_chart_sharp = IoniconsData(0xed97);
+  static const IconData? stats_chart_sharp = IoniconsData(0xed97);
 
   /// stop
-  static const IconData stop = IoniconsData(0xed98);
+  static const IconData? stop = IoniconsData(0xed98);
 
   /// stop-circle
-  static const IconData stop_circle = IoniconsData(0xed99);
+  static const IconData? stop_circle = IoniconsData(0xed99);
 
   /// stop-circle-outline
-  static const IconData stop_circle_outline = IoniconsData(0xed9a);
+  static const IconData? stop_circle_outline = IoniconsData(0xed9a);
 
   /// stop-circle-sharp
-  static const IconData stop_circle_sharp = IoniconsData(0xed9b);
+  static const IconData? stop_circle_sharp = IoniconsData(0xed9b);
 
   /// stop-outline
-  static const IconData stop_outline = IoniconsData(0xed9c);
+  static const IconData? stop_outline = IoniconsData(0xed9c);
 
   /// stop-sharp
-  static const IconData stop_sharp = IoniconsData(0xed9d);
+  static const IconData? stop_sharp = IoniconsData(0xed9d);
 
   /// stopwatch
-  static const IconData stopwatch = IoniconsData(0xed9e);
+  static const IconData? stopwatch = IoniconsData(0xed9e);
 
   /// stopwatch-outline
-  static const IconData stopwatch_outline = IoniconsData(0xed9f);
+  static const IconData? stopwatch_outline = IoniconsData(0xed9f);
 
   /// stopwatch-sharp
-  static const IconData stopwatch_sharp = IoniconsData(0xeda0);
+  static const IconData? stopwatch_sharp = IoniconsData(0xeda0);
 
   /// storefront
-  static const IconData storefront = IoniconsData(0xeda1);
+  static const IconData? storefront = IoniconsData(0xeda1);
 
   /// storefront-outline
-  static const IconData storefront_outline = IoniconsData(0xeda2);
+  static const IconData? storefront_outline = IoniconsData(0xeda2);
 
   /// storefront-sharp
-  static const IconData storefront_sharp = IoniconsData(0xeda3);
+  static const IconData? storefront_sharp = IoniconsData(0xeda3);
 
   /// subway
-  static const IconData subway = IoniconsData(0xeda4);
+  static const IconData? subway = IoniconsData(0xeda4);
 
   /// subway-outline
-  static const IconData subway_outline = IoniconsData(0xeda5);
+  static const IconData? subway_outline = IoniconsData(0xeda5);
 
   /// subway-sharp
-  static const IconData subway_sharp = IoniconsData(0xeda6);
+  static const IconData? subway_sharp = IoniconsData(0xeda6);
 
   /// sunny
-  static const IconData sunny = IoniconsData(0xeda7);
+  static const IconData? sunny = IoniconsData(0xeda7);
 
   /// sunny-outline
-  static const IconData sunny_outline = IoniconsData(0xeda8);
+  static const IconData? sunny_outline = IoniconsData(0xeda8);
 
   /// sunny-sharp
-  static const IconData sunny_sharp = IoniconsData(0xeda9);
+  static const IconData? sunny_sharp = IoniconsData(0xeda9);
 
   /// swap-horizontal
-  static const IconData swap_horizontal = IoniconsData(0xedaa);
+  static const IconData? swap_horizontal = IoniconsData(0xedaa);
 
   /// swap-horizontal-outline
-  static const IconData swap_horizontal_outline = IoniconsData(0xedab);
+  static const IconData? swap_horizontal_outline = IoniconsData(0xedab);
 
   /// swap-horizontal-sharp
-  static const IconData swap_horizontal_sharp = IoniconsData(0xedac);
+  static const IconData? swap_horizontal_sharp = IoniconsData(0xedac);
 
   /// swap-vertical
-  static const IconData swap_vertical = IoniconsData(0xedad);
+  static const IconData? swap_vertical = IoniconsData(0xedad);
 
   /// swap-vertical-outline
-  static const IconData swap_vertical_outline = IoniconsData(0xedae);
+  static const IconData? swap_vertical_outline = IoniconsData(0xedae);
 
   /// swap-vertical-sharp
-  static const IconData swap_vertical_sharp = IoniconsData(0xedaf);
+  static const IconData? swap_vertical_sharp = IoniconsData(0xedaf);
 
   /// sync
-  static const IconData sync = IoniconsData(0xedb0);
+  static const IconData? sync = IoniconsData(0xedb0);
 
   /// sync-circle
-  static const IconData sync_circle = IoniconsData(0xedb1);
+  static const IconData? sync_circle = IoniconsData(0xedb1);
 
   /// sync-circle-outline
-  static const IconData sync_circle_outline = IoniconsData(0xedb2);
+  static const IconData? sync_circle_outline = IoniconsData(0xedb2);
 
   /// sync-circle-sharp
-  static const IconData sync_circle_sharp = IoniconsData(0xedb3);
+  static const IconData? sync_circle_sharp = IoniconsData(0xedb3);
 
   /// sync-outline
-  static const IconData sync_outline = IoniconsData(0xedb4);
+  static const IconData? sync_outline = IoniconsData(0xedb4);
 
   /// sync-sharp
-  static const IconData sync_sharp = IoniconsData(0xedb5);
+  static const IconData? sync_sharp = IoniconsData(0xedb5);
 
   /// tablet-landscape
-  static const IconData tablet_landscape = IoniconsData(0xedb6);
+  static const IconData? tablet_landscape = IoniconsData(0xedb6);
 
   /// tablet-landscape-outline
-  static const IconData tablet_landscape_outline = IoniconsData(0xedb7);
+  static const IconData? tablet_landscape_outline = IoniconsData(0xedb7);
 
   /// tablet-landscape-sharp
-  static const IconData tablet_landscape_sharp = IoniconsData(0xedb8);
+  static const IconData? tablet_landscape_sharp = IoniconsData(0xedb8);
 
   /// tablet-portrait
-  static const IconData tablet_portrait = IoniconsData(0xedb9);
+  static const IconData? tablet_portrait = IoniconsData(0xedb9);
 
   /// tablet-portrait-outline
-  static const IconData tablet_portrait_outline = IoniconsData(0xedba);
+  static const IconData? tablet_portrait_outline = IoniconsData(0xedba);
 
   /// tablet-portrait-sharp
-  static const IconData tablet_portrait_sharp = IoniconsData(0xedbb);
+  static const IconData? tablet_portrait_sharp = IoniconsData(0xedbb);
 
   /// telescope
-  static const IconData telescope = IoniconsData(0xedbc);
+  static const IconData? telescope = IoniconsData(0xedbc);
 
   /// telescope-outline
-  static const IconData telescope_outline = IoniconsData(0xedbd);
+  static const IconData? telescope_outline = IoniconsData(0xedbd);
 
   /// telescope-sharp
-  static const IconData telescope_sharp = IoniconsData(0xedbe);
+  static const IconData? telescope_sharp = IoniconsData(0xedbe);
 
   /// tennisball
-  static const IconData tennisball = IoniconsData(0xedbf);
+  static const IconData? tennisball = IoniconsData(0xedbf);
 
   /// tennisball-outline
-  static const IconData tennisball_outline = IoniconsData(0xedc0);
+  static const IconData? tennisball_outline = IoniconsData(0xedc0);
 
   /// tennisball-sharp
-  static const IconData tennisball_sharp = IoniconsData(0xedc1);
+  static const IconData? tennisball_sharp = IoniconsData(0xedc1);
 
   /// terminal
-  static const IconData terminal = IoniconsData(0xedc2);
+  static const IconData? terminal = IoniconsData(0xedc2);
 
   /// terminal-outline
-  static const IconData terminal_outline = IoniconsData(0xedc3);
+  static const IconData? terminal_outline = IoniconsData(0xedc3);
 
   /// terminal-sharp
-  static const IconData terminal_sharp = IoniconsData(0xedc4);
+  static const IconData? terminal_sharp = IoniconsData(0xedc4);
 
   /// text
-  static const IconData text = IoniconsData(0xedc5);
+  static const IconData? text = IoniconsData(0xedc5);
 
   /// text-outline
-  static const IconData text_outline = IoniconsData(0xedc6);
+  static const IconData? text_outline = IoniconsData(0xedc6);
 
   /// text-sharp
-  static const IconData text_sharp = IoniconsData(0xedc7);
+  static const IconData? text_sharp = IoniconsData(0xedc7);
 
   /// thermometer
-  static const IconData thermometer = IoniconsData(0xedc8);
+  static const IconData? thermometer = IoniconsData(0xedc8);
 
   /// thermometer-outline
-  static const IconData thermometer_outline = IoniconsData(0xedc9);
+  static const IconData? thermometer_outline = IoniconsData(0xedc9);
 
   /// thermometer-sharp
-  static const IconData thermometer_sharp = IoniconsData(0xedca);
+  static const IconData? thermometer_sharp = IoniconsData(0xedca);
 
   /// thumbs-down
-  static const IconData thumbs_down = IoniconsData(0xedcb);
+  static const IconData? thumbs_down = IoniconsData(0xedcb);
 
   /// thumbs-down-outline
-  static const IconData thumbs_down_outline = IoniconsData(0xedcc);
+  static const IconData? thumbs_down_outline = IoniconsData(0xedcc);
 
   /// thumbs-down-sharp
-  static const IconData thumbs_down_sharp = IoniconsData(0xedcd);
+  static const IconData? thumbs_down_sharp = IoniconsData(0xedcd);
 
   /// thumbs-up
-  static const IconData thumbs_up = IoniconsData(0xedce);
+  static const IconData? thumbs_up = IoniconsData(0xedce);
 
   /// thumbs-up-outline
-  static const IconData thumbs_up_outline = IoniconsData(0xedcf);
+  static const IconData? thumbs_up_outline = IoniconsData(0xedcf);
 
   /// thumbs-up-sharp
-  static const IconData thumbs_up_sharp = IoniconsData(0xedd0);
+  static const IconData? thumbs_up_sharp = IoniconsData(0xedd0);
 
   /// thunderstorm
-  static const IconData thunderstorm = IoniconsData(0xedd1);
+  static const IconData? thunderstorm = IoniconsData(0xedd1);
 
   /// thunderstorm-outline
-  static const IconData thunderstorm_outline = IoniconsData(0xedd2);
+  static const IconData? thunderstorm_outline = IoniconsData(0xedd2);
 
   /// thunderstorm-sharp
-  static const IconData thunderstorm_sharp = IoniconsData(0xedd3);
+  static const IconData? thunderstorm_sharp = IoniconsData(0xedd3);
 
   /// ticket
-  static const IconData ticket = IoniconsData(0xedd4);
+  static const IconData? ticket = IoniconsData(0xedd4);
 
   /// ticket-outline
-  static const IconData ticket_outline = IoniconsData(0xedd5);
+  static const IconData? ticket_outline = IoniconsData(0xedd5);
 
   /// ticket-sharp
-  static const IconData ticket_sharp = IoniconsData(0xedd6);
+  static const IconData? ticket_sharp = IoniconsData(0xedd6);
 
   /// time
-  static const IconData time = IoniconsData(0xedd7);
+  static const IconData? time = IoniconsData(0xedd7);
 
   /// time-outline
-  static const IconData time_outline = IoniconsData(0xedd8);
+  static const IconData? time_outline = IoniconsData(0xedd8);
 
   /// timer
-  static const IconData timer = IoniconsData(0xedd9);
+  static const IconData? timer = IoniconsData(0xedd9);
 
   /// timer-outline
-  static const IconData timer_outline = IoniconsData(0xedda);
+  static const IconData? timer_outline = IoniconsData(0xedda);
 
   /// timer-sharp
-  static const IconData timer_sharp = IoniconsData(0xeddb);
+  static const IconData? timer_sharp = IoniconsData(0xeddb);
 
   /// time-sharp
-  static const IconData time_sharp = IoniconsData(0xeddc);
+  static const IconData? time_sharp = IoniconsData(0xeddc);
 
   /// today
-  static const IconData today = IoniconsData(0xeddd);
+  static const IconData? today = IoniconsData(0xeddd);
 
   /// today-outline
-  static const IconData today_outline = IoniconsData(0xedde);
+  static const IconData? today_outline = IoniconsData(0xedde);
 
   /// today-sharp
-  static const IconData today_sharp = IoniconsData(0xeddf);
+  static const IconData? today_sharp = IoniconsData(0xeddf);
 
   /// toggle
-  static const IconData toggle = IoniconsData(0xede0);
+  static const IconData? toggle = IoniconsData(0xede0);
 
   /// toggle-outline
-  static const IconData toggle_outline = IoniconsData(0xede1);
+  static const IconData? toggle_outline = IoniconsData(0xede1);
 
   /// toggle-sharp
-  static const IconData toggle_sharp = IoniconsData(0xede2);
+  static const IconData? toggle_sharp = IoniconsData(0xede2);
 
   /// trail-sign
-  static const IconData trail_sign = IoniconsData(0xede3);
+  static const IconData? trail_sign = IoniconsData(0xede3);
 
   /// trail-sign-outline
-  static const IconData trail_sign_outline = IoniconsData(0xede4);
+  static const IconData? trail_sign_outline = IoniconsData(0xede4);
 
   /// trail-sign-sharp
-  static const IconData trail_sign_sharp = IoniconsData(0xede5);
+  static const IconData? trail_sign_sharp = IoniconsData(0xede5);
 
   /// train
-  static const IconData train = IoniconsData(0xede6);
+  static const IconData? train = IoniconsData(0xede6);
 
   /// train-outline
-  static const IconData train_outline = IoniconsData(0xede7);
+  static const IconData? train_outline = IoniconsData(0xede7);
 
   /// train-sharp
-  static const IconData train_sharp = IoniconsData(0xede8);
+  static const IconData? train_sharp = IoniconsData(0xede8);
 
   /// transgender
-  static const IconData transgender = IoniconsData(0xede9);
+  static const IconData? transgender = IoniconsData(0xede9);
 
   /// transgender-outline
-  static const IconData transgender_outline = IoniconsData(0xedea);
+  static const IconData? transgender_outline = IoniconsData(0xedea);
 
   /// transgender-sharp
-  static const IconData transgender_sharp = IoniconsData(0xedeb);
+  static const IconData? transgender_sharp = IoniconsData(0xedeb);
 
   /// trash
-  static const IconData trash = IoniconsData(0xedec);
+  static const IconData? trash = IoniconsData(0xedec);
 
   /// trash-bin
-  static const IconData trash_bin = IoniconsData(0xeded);
+  static const IconData? trash_bin = IoniconsData(0xeded);
 
   /// trash-bin-outline
-  static const IconData trash_bin_outline = IoniconsData(0xedee);
+  static const IconData? trash_bin_outline = IoniconsData(0xedee);
 
   /// trash-bin-sharp
-  static const IconData trash_bin_sharp = IoniconsData(0xedef);
+  static const IconData? trash_bin_sharp = IoniconsData(0xedef);
 
   /// trash-outline
-  static const IconData trash_outline = IoniconsData(0xedf0);
+  static const IconData? trash_outline = IoniconsData(0xedf0);
 
   /// trash-sharp
-  static const IconData trash_sharp = IoniconsData(0xedf1);
+  static const IconData? trash_sharp = IoniconsData(0xedf1);
 
   /// trending-down
-  static const IconData trending_down = IoniconsData(0xedf2);
+  static const IconData? trending_down = IoniconsData(0xedf2);
 
   /// trending-down-outline
-  static const IconData trending_down_outline = IoniconsData(0xedf3);
+  static const IconData? trending_down_outline = IoniconsData(0xedf3);
 
   /// trending-down-sharp
-  static const IconData trending_down_sharp = IoniconsData(0xedf4);
+  static const IconData? trending_down_sharp = IoniconsData(0xedf4);
 
   /// trending-up
-  static const IconData trending_up = IoniconsData(0xedf5);
+  static const IconData? trending_up = IoniconsData(0xedf5);
 
   /// trending-up-outline
-  static const IconData trending_up_outline = IoniconsData(0xedf6);
+  static const IconData? trending_up_outline = IoniconsData(0xedf6);
 
   /// trending-up-sharp
-  static const IconData trending_up_sharp = IoniconsData(0xedf7);
+  static const IconData? trending_up_sharp = IoniconsData(0xedf7);
 
   /// triangle
-  static const IconData triangle = IoniconsData(0xedf8);
+  static const IconData? triangle = IoniconsData(0xedf8);
 
   /// triangle-outline
-  static const IconData triangle_outline = IoniconsData(0xedf9);
+  static const IconData? triangle_outline = IoniconsData(0xedf9);
 
   /// triangle-sharp
-  static const IconData triangle_sharp = IoniconsData(0xedfa);
+  static const IconData? triangle_sharp = IoniconsData(0xedfa);
 
   /// trophy
-  static const IconData trophy = IoniconsData(0xedfb);
+  static const IconData? trophy = IoniconsData(0xedfb);
 
   /// trophy-outline
-  static const IconData trophy_outline = IoniconsData(0xedfc);
+  static const IconData? trophy_outline = IoniconsData(0xedfc);
 
   /// trophy-sharp
-  static const IconData trophy_sharp = IoniconsData(0xedfd);
+  static const IconData? trophy_sharp = IoniconsData(0xedfd);
 
   /// tv
-  static const IconData tv = IoniconsData(0xedfe);
+  static const IconData? tv = IoniconsData(0xedfe);
 
   /// tv-outline
-  static const IconData tv_outline = IoniconsData(0xedff);
+  static const IconData? tv_outline = IoniconsData(0xedff);
 
   /// tv-sharp
-  static const IconData tv_sharp = IoniconsData(0xee00);
+  static const IconData? tv_sharp = IoniconsData(0xee00);
 
   /// umbrella
-  static const IconData umbrella = IoniconsData(0xee01);
+  static const IconData? umbrella = IoniconsData(0xee01);
 
   /// umbrella-outline
-  static const IconData umbrella_outline = IoniconsData(0xee02);
+  static const IconData? umbrella_outline = IoniconsData(0xee02);
 
   /// umbrella-sharp
-  static const IconData umbrella_sharp = IoniconsData(0xee03);
+  static const IconData? umbrella_sharp = IoniconsData(0xee03);
 
   /// unlink
-  static const IconData unlink = IoniconsData(0xee04);
+  static const IconData? unlink = IoniconsData(0xee04);
 
   /// unlink-outline
-  static const IconData unlink_outline = IoniconsData(0xee05);
+  static const IconData? unlink_outline = IoniconsData(0xee05);
 
   /// unlink-sharp
-  static const IconData unlink_sharp = IoniconsData(0xee06);
+  static const IconData? unlink_sharp = IoniconsData(0xee06);
 
   /// videocam
-  static const IconData videocam = IoniconsData(0xee07);
+  static const IconData? videocam = IoniconsData(0xee07);
 
   /// videocam-off
-  static const IconData videocam_off = IoniconsData(0xee08);
+  static const IconData? videocam_off = IoniconsData(0xee08);
 
   /// videocam-off-outline
-  static const IconData videocam_off_outline = IoniconsData(0xee09);
+  static const IconData? videocam_off_outline = IoniconsData(0xee09);
 
   /// videocam-off-sharp
-  static const IconData videocam_off_sharp = IoniconsData(0xee0a);
+  static const IconData? videocam_off_sharp = IoniconsData(0xee0a);
 
   /// videocam-outline
-  static const IconData videocam_outline = IoniconsData(0xee0b);
+  static const IconData? videocam_outline = IoniconsData(0xee0b);
 
   /// videocam-sharp
-  static const IconData videocam_sharp = IoniconsData(0xee0c);
+  static const IconData? videocam_sharp = IoniconsData(0xee0c);
 
   /// volume-high
-  static const IconData volume_high = IoniconsData(0xee0d);
+  static const IconData? volume_high = IoniconsData(0xee0d);
 
   /// volume-high-outline
-  static const IconData volume_high_outline = IoniconsData(0xee0e);
+  static const IconData? volume_high_outline = IoniconsData(0xee0e);
 
   /// volume-high-sharp
-  static const IconData volume_high_sharp = IoniconsData(0xee0f);
+  static const IconData? volume_high_sharp = IoniconsData(0xee0f);
 
   /// volume-low
-  static const IconData volume_low = IoniconsData(0xee10);
+  static const IconData? volume_low = IoniconsData(0xee10);
 
   /// volume-low-outline
-  static const IconData volume_low_outline = IoniconsData(0xee11);
+  static const IconData? volume_low_outline = IoniconsData(0xee11);
 
   /// volume-low-sharp
-  static const IconData volume_low_sharp = IoniconsData(0xee12);
+  static const IconData? volume_low_sharp = IoniconsData(0xee12);
 
   /// volume-medium
-  static const IconData volume_medium = IoniconsData(0xee13);
+  static const IconData? volume_medium = IoniconsData(0xee13);
 
   /// volume-medium-outline
-  static const IconData volume_medium_outline = IoniconsData(0xee14);
+  static const IconData? volume_medium_outline = IoniconsData(0xee14);
 
   /// volume-medium-sharp
-  static const IconData volume_medium_sharp = IoniconsData(0xee15);
+  static const IconData? volume_medium_sharp = IoniconsData(0xee15);
 
   /// volume-mute
-  static const IconData volume_mute = IoniconsData(0xee16);
+  static const IconData? volume_mute = IoniconsData(0xee16);
 
   /// volume-mute-outline
-  static const IconData volume_mute_outline = IoniconsData(0xee17);
+  static const IconData? volume_mute_outline = IoniconsData(0xee17);
 
   /// volume-mute-sharp
-  static const IconData volume_mute_sharp = IoniconsData(0xee18);
+  static const IconData? volume_mute_sharp = IoniconsData(0xee18);
 
   /// volume-off
-  static const IconData volume_off = IoniconsData(0xee19);
+  static const IconData? volume_off = IoniconsData(0xee19);
 
   /// volume-off-outline
-  static const IconData volume_off_outline = IoniconsData(0xee1a);
+  static const IconData? volume_off_outline = IoniconsData(0xee1a);
 
   /// volume-off-sharp
-  static const IconData volume_off_sharp = IoniconsData(0xee1b);
+  static const IconData? volume_off_sharp = IoniconsData(0xee1b);
 
   /// walk
-  static const IconData walk = IoniconsData(0xee1c);
+  static const IconData? walk = IoniconsData(0xee1c);
 
   /// walk-outline
-  static const IconData walk_outline = IoniconsData(0xee1d);
+  static const IconData? walk_outline = IoniconsData(0xee1d);
 
   /// walk-sharp
-  static const IconData walk_sharp = IoniconsData(0xee1e);
+  static const IconData? walk_sharp = IoniconsData(0xee1e);
 
   /// wallet
-  static const IconData wallet = IoniconsData(0xee1f);
+  static const IconData? wallet = IoniconsData(0xee1f);
 
   /// wallet-outline
-  static const IconData wallet_outline = IoniconsData(0xee20);
+  static const IconData? wallet_outline = IoniconsData(0xee20);
 
   /// wallet-sharp
-  static const IconData wallet_sharp = IoniconsData(0xee21);
+  static const IconData? wallet_sharp = IoniconsData(0xee21);
 
   /// warning
-  static const IconData warning = IoniconsData(0xee22);
+  static const IconData? warning = IoniconsData(0xee22);
 
   /// warning-outline
-  static const IconData warning_outline = IoniconsData(0xee23);
+  static const IconData? warning_outline = IoniconsData(0xee23);
 
   /// warning-sharp
-  static const IconData warning_sharp = IoniconsData(0xee24);
+  static const IconData? warning_sharp = IoniconsData(0xee24);
 
   /// watch
-  static const IconData watch = IoniconsData(0xee25);
+  static const IconData? watch = IoniconsData(0xee25);
 
   /// watch-outline
-  static const IconData watch_outline = IoniconsData(0xee26);
+  static const IconData? watch_outline = IoniconsData(0xee26);
 
   /// watch-sharp
-  static const IconData watch_sharp = IoniconsData(0xee27);
+  static const IconData? watch_sharp = IoniconsData(0xee27);
 
   /// water
-  static const IconData water = IoniconsData(0xee28);
+  static const IconData? water = IoniconsData(0xee28);
 
   /// water-outline
-  static const IconData water_outline = IoniconsData(0xee29);
+  static const IconData? water_outline = IoniconsData(0xee29);
 
   /// water-sharp
-  static const IconData water_sharp = IoniconsData(0xee2a);
+  static const IconData? water_sharp = IoniconsData(0xee2a);
 
   /// wifi
-  static const IconData wifi = IoniconsData(0xee2b);
+  static const IconData? wifi = IoniconsData(0xee2b);
 
   /// wifi-outline
-  static const IconData wifi_outline = IoniconsData(0xee2c);
+  static const IconData? wifi_outline = IoniconsData(0xee2c);
 
   /// wifi-sharp
-  static const IconData wifi_sharp = IoniconsData(0xee2d);
+  static const IconData? wifi_sharp = IoniconsData(0xee2d);
 
   /// wine
-  static const IconData wine = IoniconsData(0xee2e);
+  static const IconData? wine = IoniconsData(0xee2e);
 
   /// wine-outline
-  static const IconData wine_outline = IoniconsData(0xee2f);
+  static const IconData? wine_outline = IoniconsData(0xee2f);
 
   /// wine-sharp
-  static const IconData wine_sharp = IoniconsData(0xee30);
+  static const IconData? wine_sharp = IoniconsData(0xee30);
 
   /// woman
-  static const IconData woman = IoniconsData(0xee31);
+  static const IconData? woman = IoniconsData(0xee31);
 
   /// woman-outline
-  static const IconData woman_outline = IoniconsData(0xee32);
+  static const IconData? woman_outline = IoniconsData(0xee32);
 
   /// woman-sharp
-  static const IconData woman_sharp = IoniconsData(0xee33);
+  static const IconData? woman_sharp = IoniconsData(0xee33);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.3"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.5"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.5"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.3"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.6"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,56 +92,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.4"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.6"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.6"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.5"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.1
 homepage: https://github.com/ez-connect/flutter-ionicons
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
## What?
Support for null safe projects.
## Why?
Because the package, as it currently is, does not work with projects that have null-safety enabled.
## How?
- run `dart migrate`
- fix conflicting variables.
## Anything Else?
This package is very lovely, it's very unfortunate to be unable to use it in null safe projects. I am pretty sure people would be happy to see a new version of it with null safety enabled.